### PR TITLE
Chore/fix filter andsize logics

### DIFF
--- a/attention-bank/bank/atombins.metta
+++ b/attention-bank/bank/atombins.metta
@@ -85,7 +85,7 @@
 
 ;predicate function to check if a list is empty
 (: notEmpty (-> Expression Bool))
-(= (notEmpty ($x $y)) (> (size $y 0) 0 ))
+(= (notEmpty ($x $y)) (> (size $y) 0 ))
 
 ;this function randomly selects a bin from atombins and proceeds to randomly choose a single element from selected random bin.
 (: getRandomAtom (-> Symbol))

--- a/attention-bank/bank/atombins.metta
+++ b/attention-bank/bank/atombins.metta
@@ -93,7 +93,7 @@
    (
     let*(
          ($handleSetSeq (collapseAtomBin &atombin))
-         ($filteredOutput (filter $handleSetSeq notEmpty))
+         ($filteredOutput (filter $handleSetSeq notEmpty ()))
         )
     (if(== $filteredOutput ()) ;check if all bins in atom bins are empty
       empty
@@ -127,7 +127,7 @@
    let*(
         ($handleSetSeq (collapseAtomBin &atombin))
         ($handleSet (valuesAtIndex $index $handleSetSeq))
-        ($filteredOutput (filter $handleSet $predicate))
+        ($filteredOutput (filter $handleSet $predicate ()))
       )
       $filteredOutput
   )

--- a/attention-bank/tests/atombins-test.metta
+++ b/attention-bank/tests/atombins-test.metta
@@ -14,7 +14,7 @@
 !(setAv d (7 4 0))
 !(setAv c (0 0 0))
 
-!(let $res (collapse (getRandomAtom)) (assertEqual (size $res 0) 1))
+!(let $res (collapse (getRandomAtom)) (assertEqual (size $res) 1))
 ;
 ;;; Example Predicate function
 (= (pred $x) (

--- a/attention-bank/tests/helper-functions-test.metta
+++ b/attention-bank/tests/helper-functions-test.metta
@@ -3,14 +3,14 @@
 !(import! &self metta-attention:attention-bank:bank:atombins)
 
 !(assertEqual 
-              (filter ((3 (c)) (1 (a)) (37 (f h j k)) (17 (s c)) (18 (g j)) (2 (d)) (27 ())) notEmpty) 
+              (filter ((3 (c)) (1 (a)) (37 (f h j k)) (17 (s c)) (18 (g j)) (2 (d)) (27 ())) notEmpty ()) 
               ((3 (c)) (1 (a)) (37 (f h j k)) (17 (s c)) (18 (g j)) (2 (d)))
 )
 
-!(assertEqual (filter ((1 ()) (2 ())) notEmpty) ())
+!(assertEqual (filter ((1 ()) (2 ())) notEmpty ()) ())
 
-!(assertEqual (size ((3 (c)) (1 (a)) (37 (f h j k)) (17 (s c)) (18 (g j)) (2 (d))) 0) 6)
-!(assertEqual (size () 0) 0)
+!(assertEqual (size ((3 (c)) (1 (a)) (37 (f h j k)) (17 (s c)) (18 (g j)) (2 (d)))) 6)
+!(assertEqual (size ()) 0)
 
 ! (assertEqual (Max (1 2 3 17 18 37)) 37)
 ! (assertEqual (Max (34 22 1 17 18 107)) 107)

--- a/attention-bank/utilities/helper-functions.metta
+++ b/attention-bank/utilities/helper-functions.metta
@@ -1,18 +1,20 @@
-(: filter (-> Expression (-> $t Bool) Expression))
-(= (filter () $predicate) ())
-(= (filter $list $predicate)
-   (let*
-     (
-        ($head (car-atom $list))
-        ($tail (cdr-atom $list))
-        ($res ($predicate $head))
-        ($filteredTail (filter $tail $predicate))
-     )
-     (if $res
-        (cons-atom $head $filteredTail)
-        $filteredTail
-       )
-    )
+(: filter (-> Expression (-> $t Bool) Expression Expression))
+(= (filter $list $predicate $acc)
+   (if (== $list ())
+    $acc
+    (let*
+      (
+          ($head (car-atom $list))
+          ($tail (cdr-atom $list))
+          ($res ($predicate $head))
+          ($filteredTail (filter $tail $predicate $acc))
+      )
+      (if $res
+          (cons-atom $head $filteredTail)
+          $filteredTail
+        )
+      )
+   )
 )
 
 (: valuesAtIndex (-> Number Expression Expression))
@@ -32,14 +34,11 @@
   )
 )
 
-(: size (-> Expression Number Number))
-(= (size () $s) $s)
-(= (size $list $s)
-   (let*(
-         ($head (car-atom $list))
-         ($tail (cdr-atom $list))
-        )
-     (size $tail (+ 1 $s))
+(: size (-> Expression Number))
+(= (size $list)
+   (if (== $list ())
+      0
+      (let $tail (cdr-atom $list) (+ 1 (size $tail)))
     )
 )
 


### PR DESCRIPTION
I have refactored the `filter` and `size` functions I had previously implemented as helper functions. The changes introduced are as follows:
- filter function now accepts an accumulator, it checks if `$list` is empty as opposed to the previous implementation which caused infinite loops.
- size function now does not accept an accumulator and its base case has been changed to check if `== $list ()`.
- these two changes have been propagated to `getContentIf`, `getRandomAtom` and the corresponding test cases in the their respective test files.