### PR TITLE
Refactor for &atombin space access from outside the immediate file the space is declared in.

### DIFF
--- a/attention-bank/bank/atombins.metta
+++ b/attention-bank/bank/atombins.metta
@@ -152,3 +152,4 @@
  )
 )
 
+(= (AtomBin) &atombin) ; to be able to reference atombins from outside this metta file.

--- a/attention-bank/bank/attention-bank.metta
+++ b/attention-bank/bank/attention-bank.metta
@@ -1,6 +1,5 @@
 ; Define initial variables and insert them in newspace called space
 !(bind! &space (new-space))
-!(bind! &atombin (new-space))
 !(add-atom &space (startingFundsSTI 100000))
 !(add-atom &space (fundsSTI 100000))
 !(add-atom &space (startingFundsLTI 100000))
@@ -128,7 +127,8 @@
          ($_ (updateLTIFunds $oldLTIFund $newLTIFund))
          ($_ (updateSTIFunds $oldSTIFund $newSTIFund))
          ($_ (updateAttentionalFocus $pattern))
-         ($r (update &atombin))
+         ($atombin (AtomBin))
+         ($r (update $atombin))
         )
         $r
     )

--- a/attention-bank/bank/get-min-max-content.metta
+++ b/attention-bank/bank/get-min-max-content.metta
@@ -1,12 +1,11 @@
-!(bind! &atombin (new-space))
-
 ; this function take atoms from atombin space and return atoms found inside the largest bin index
 ; it uses Max helper function to get the largest bin index then it returns the atom found in that bin index
 (= (getMaxContent) 
     (let* (
-        ($numbers (collapse (match &atombin ($y $x) $y)))
+        ($atombin (AtomBin))
+        ($numbers (collapse (match $atombin ($y $x) $y)))
         ($max (Max $numbers))
-        ($content (match &atombin ($max $x)  $x))
+        ($content (match (AtomBin) ($max $x)  $x))
     )
         $content
     )
@@ -15,45 +14,50 @@
 ; it uses Min helper function to get the smallest bin index then it returns the atom found in that bin index
 (= (getMinContent)
     (let* (
-        ($numbers (collapse (match &atombin ($y $x) $y)))
+        ($atombin (AtomBin))
+        ($numbers (collapse (match $atombin ($y $x) $y)))
         ($min (Min $numbers))
-        ($content (match &atombin ($min $x)  $x))
-    )
-        $content
+        ($content (match (AtomBin) ($min $x)  $x))
+      )
+      $content
     )
 )
 
 ; this function takes a bin number and return the number of atoms found in that bin
-; it used length helper function to count the number of atoms found in the bin
+; it used size helper function to count the number of atoms found in the bin
 (= (getSize $binNumber)
     (let* (
-        ($atoms (match &atombin ($binNumber $x) $x))
-    )
-        (size $atoms)
+        ($atombin (AtomBin))
+        ($atoms (match $atombin ($binNumber $x) $x))
+        ($size (size $atoms))
+      )
+      $size
     )
 )
+
 ; Calculates the total number of atoms across all bins in &atombin
 (: binSize (-> Number))
 (= (binSize)
-   (let $bins (collapse (match &atombin ($index $contents) $index))
-        (if (== $bins ()) 
-          0
-          (sumSizes $bins)
-        )
+   (let* (
+      ($atombin (AtomBin))
+      ($indices (collapse (match $atombin ($x $y) $x)))
+      ($binsSize (sumSizes $indices)) ;cumulative sum of all sizes of bins in atombin
     )
-) 
+    $binsSize
+  )
+)
+
 ; Recursively sums the sizes of all bins in a list of bins
 (: sumSizes (-> Expression Number))
-(= (sumSizes $bins)
-   (if(== $bins ())
-        0 
-        (let $bin (car-atom $bins)
-            (let $rest (cdr-atom $bins)
-                (if (== $rest ()) 
-                    (getSize $bin) 
-                    (+ (getSize $bin) (sumSizes $rest))
-                )
+(= (sumSizes $indices)
+   (if (== $indices ())
+      0
+      (let* (
+             ($index (car-atom $indices))
+             ($rest (cdr-atom $indices))
+             ($remainingSize (sumSizes $rest))
             )
-        )
+        (+ (getSize $index) $remainingSize)
+       )
     )
 )

--- a/attention-bank/tests/get-min-max-content-test.metta
+++ b/attention-bank/tests/get-min-max-content-test.metta
@@ -1,5 +1,6 @@
 !(register-module! ../../../metta-attention)
 !(import! &self metta-attention:attention-bank:bank:get-min-max-content)
+!(import! &self metta-attention:attention-bank:bank:atombins)
 !(import! &self metta-attention:attention-bank:utilities:helper-functions)
 
 
@@ -10,11 +11,9 @@
 !(add-atom &atombin (18 (g j)))
 !(add-atom &atombin (37 (f h j k)))
 
-
 ! (assertEqual (getMaxContent) (f h j k))
 ! (assertEqual (getMinContent) (a))
 ! (assertEqual (Max (1 2 3 17 18 37)) 37)
-
 
 ! (assertEqual (getSize 1) 1)
 ! (assertEqual (getSize 17) 2)


### PR DESCRIPTION
This PR holds changes in the way &atombin space has been accessed from outside its declaration file (atombins.metta).
Although I do not know why it is, when referencing spaces that are declared in different files, directly trying to access them by their identifiers like &atombin won't work. However, it works when an Expression that returns the grounded identifier is returned. 

I have also refactored getSizes and binSize functions from get-min-max... file. The previous implementation worked fine however it lacked readability. 