### PR TITLE
Optimizations on the attentiona-focus module

### DIFF
--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -38,12 +38,7 @@
 ;it returns the total number of atoms in the attentional focus
 (: attentionalFocusSize (-> Number))
 (= (attentionalFocusSize)
-    (let $atoms (getAtomList)
-        (if (== $atoms ())
-            0
-            (size $atoms)
-        )
-    )
+    (size (getAtomList))
 )
 
 ; Helper function for filtering atoms with STI less than the pivot

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -165,10 +165,7 @@
            ($maxSize (maxAFSize)) 
            ($sti (getSTI $atom)) 
            ($currentSize (attentionalFocusSize)) 
-           ($lowestAtom (getLowestStiAtomInAF)) 
            ($isInAF (atomIsInAF $atom)) ; Check if atom is already in AF
-           ($canAdd (< $currentSize $maxSize)) ; Check if AF is not full
-           ($shouldReplace (> $sti (getSTI $lowestAtom))) ; Check if replacement is needed
        )
 
        (if $isInAF
@@ -177,18 +174,18 @@
                (remove-atom &attentionalFocus $atom)
                (addAtomToAF $atom)
            )
-           (if $canAdd
+           (if (< $currentSize $maxSize)
                ; Case 2: AF is not full, add the new atom
                (addAtomToAF $atom)
 
-               (if $shouldReplace
-                   ; Case 3: Replace the lowest STI atom with the new atom
-                   (let ()
-                       (remove-atom &attentionalFocus $lowestAtom)
-                       (addAtomToAF $atom)
-                   )
-                   ; Case 4: Atom not added (STI is too low)
-                   (empty)
+               (let $lowestAtom (getLowestStiAtomInAF) ; Only compute if needed
+                    (if (> $sti (getSTI $lowestAtom))  ; Case 3: Replace if better
+                        (let ()
+                            (remove-atom &attentionalFocus $lowestAtom)
+                            (addAtomToAF $atom)
+                        )
+                        (empty) ; Case 4: Atom not added
+                    )
                )
            )
        )

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -104,12 +104,26 @@
 
 
 ;gets the atom with the lowest STI value in the attentional focus
-(:getLowestStiAtomInAF (-> Number))
-(=(getLowestStiAtomInAF)
-    (let $sortedAtoms (sortAtomsBySti  (getAtomList))
-        (if (==  $sortedAtoms ())
+;(: getLowestStiAtomInAFHelper (-> List Atom Number Atom))
+(= (getLowestStiAtomInAFHelper $atoms $minAtom $minSTI)
+    (if (== $atoms ())
+        $minAtom
+        (let* (
+            ($current (car-atom $atoms))
+            ($sti (getSTI $current))
+            ($newMinAtom (if (< $sti $minSTI) $current $minAtom))
+            ($newMinSTI (if (< $sti $minSTI) $sti $minSTI))
+        )
+        (getLowestStiAtomInAFHelper (cdr-atom $atoms) $newMinAtom $newMinSTI))
+    )
+)
+
+(: getLowestStiAtomInAF (-> Atom))
+(= (getLowestStiAtomInAF)
+    (let $atoms (getAtomList)
+        (if (== $atoms ())
             ()
-            (car-atom  $sortedAtoms)
+            (getLowestStiAtomInAFHelper $atoms (car-atom $atoms) (getSTI (car-atom $atoms)))
         )
     )
 )

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -129,20 +129,29 @@
 )
 
 ;gets the maximum STI value in the attentional focus
-(: getAfMaxSTI (-> Number))
-(=(getAfMaxSTI)
-    (let $sortedAtoms (sortAtomsByStiDescending (getAtomList))
-        (if (==  $sortedAtoms ())
-            0
-            (let $maxAtom (car-atom $sortedAtoms)
-                    (getSTI $maxAtom)
-            )
+;(: getAfMaxSTIHelper (-> List Atom Number Atom))
+(= (getAfMaxSTIHelper $atoms $maxAtom $maxSTI)
+    (if (== $atoms ())
+        $maxSTI
+        (let* (
+            ($current (car-atom $atoms))
+            ($sti (getSTI $current))
+            ($newMaxAtom (if (> $sti $maxSTI) $current $maxAtom))
+            ($newMaxSTI (if (> $sti $maxSTI) $sti $maxSTI))
         )
+        (getAfMaxSTIHelper (cdr-atom $atoms) $newMaxAtom $newMaxSTI))
     )
 )
 
-
-    
+(: getAfMaxSTI (-> Number))
+(= (getAfMaxSTI)
+    (let $atoms (getAtomList)
+        (if (== $atoms ())
+            0
+            (getAfMaxSTIHelper $atoms (car-atom $atoms) (getSTI (car-atom $atoms)))
+        )
+    )
+)
 
 ;the function below updates the attentional focus with a new atom
 ;the RemoveAFSignal() and AddAFSignal() functions have been skiped in this function because it appears to primarily 

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -3,6 +3,7 @@
 (= (maxAFSize) 100)
 
 ;checks if an atom is in attentional focus
+
 (: atomIsInAF (-> Atom Bool))
 (= (atomIsInAF $atom)
    (if  (== (collapse (match &attentionalFocus $atom $atom)) ())
@@ -12,12 +13,14 @@
 )
 
 ;checks if an atom is in attentional focus
+
 (: atomIsNotInAF (-> Atom Bool))
 (= (atomIsNotInAF $atom)
    (not (atomIsInAF $atom))
 )
 
 ;adds an atom to the attentional focus if it is valid
+
 (: addAtomToAF (-> Atom Symbol))
 (= (addAtomToAF $atom)
    (if (== (getType $atom) %Undefined%)
@@ -30,18 +33,21 @@
 )
 
 ; Collapse space to list of atoms
+
 (: getAtomList(->Symbol))
 (= (getAtomList)
    (collapse (get-atoms &attentionalFocus))
 )
 
 ;it returns the total number of atoms in the attentional focus
+
 (: attentionalFocusSize (-> Number))
 (= (attentionalFocusSize)
     (size (getAtomList))
 )
 
 ; Helper function for filtering atoms with STI less than the pivot
+
 (: lessThanSti (-> Atom Atom Bool))
 (= (lessThanSti $elem $pivot)
     (if (or (== $elem ()) (== $pivot ())) 
@@ -51,6 +57,7 @@
 )
 
 ; Helper function for filtering atoms with STI greater than or equal to the pivot
+
 (: greaterEqualSti (-> Atom Atom Bool))
 (= (greaterEqualSti $elem $pivot)
     (if (or (== $elem ()) (== $pivot ())) 
@@ -60,6 +67,7 @@
 )
 
 ; Sorts a list of atoms by their STI values in ascending order
+
 (: sortAtomsBySti (-> Symbol Symbol))
 (= (sortAtomsBySti $atoms)
     (if (== $atoms ())
@@ -80,6 +88,7 @@
 )
 
 ; Sorts a list of atoms by their STI values in descending order
+
 (: sortAtomsByStiDescending (-> Symbol Symbol))
 (= (sortAtomsByStiDescending $atoms)
     (if (== $atoms ())
@@ -98,12 +107,8 @@
     )
 )
 
-
-
-
-
-
 ;gets the atom with the lowest STI value in the attentional focus
+
 ;(: getLowestStiAtomInAFHelper (-> List Atom Number Atom))
 (= (getLowestStiAtomInAFHelper $atoms $minAtom $minSTI)
     (if (== $atoms ())
@@ -129,6 +134,7 @@
 )
 
 ;gets the maximum STI value in the attentional focus
+
 ;(: getAfMaxSTIHelper (-> List Atom Number Atom))
 (= (getAfMaxSTIHelper $atoms $maxAtom $maxSTI)
     (if (== $atoms ())
@@ -192,12 +198,8 @@
    )
 )
 
-
-
-
-
-
 ; Function to retrieve a random atom not in attentional focus
+
 (: getRandomAtomNotInAF (-> Atom))
 (= (getRandomAtomNotInAF)
    (let*
@@ -227,6 +229,7 @@
 ;;;   $atom: The atom for which to find incoming links.
 ;;;   $type: The type of link to consider.
 ;;; Returns: A list of incoming links that are in the AF.
+
 (: getIncomingSet (-> Atom Type List))
 (= (getIncomingSet $atom $type)
     (let* (
@@ -243,6 +246,7 @@
 ;;; Parameters:
 ;;;   $incoming_set: A list of incoming links to filter.
 ;;; Returns: A new list containing only the links that are in the AF.
+
 (: filterLinksInAF (-> List List))
 (= (filterLinksInAF $incoming_set)
     (if (== $incoming_set ())
@@ -261,6 +265,7 @@
         )
     )
 )
+
 ;;; Function: getIncomingSetByType
 ;;; Description: Retrieves the set of incoming links of a specific type for a given atom
 ;;;              without filtering based on the active frame.
@@ -268,6 +273,7 @@
 ;;;   $atom: The atom for which to find incoming links.
 ;;;   $type: The type of link to consider.
 ;;; Returns: A list of incoming links of the specified type.
+
 (: getIncomingSetByType (-> Atom Type List))
 (= (getIncomingSetByType $atom $type)
     (collapse 
@@ -282,6 +288,7 @@
 
 ;This function simply matches if two nodes are equal and they are in AF
 (:nodeMatch (-> Atom Atom Bool))
+
 (= (nodeMatch $node1 $node2)
     (if (and (== $node1 $node2) (atomIsInAF $node2))
         True

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -270,11 +270,13 @@
 ;;; Returns: A list of incoming links of the specified type.
 (: getIncomingSetByType (-> Atom Type List))
 (= (getIncomingSetByType $atom $type)
-    (let* (
-          ($linkVariationOne (collapse (match &attentionalFocus ($type $atom $b) ($type $atom $b))))
-          ($linkVariationTwo (collapse (match &attentionalFocus ($type $a $atom) ($type $a $atom))))
-          )
-        (concatTuple $linkVariationOne $linkVariationTwo)
+    (collapse 
+        (superpose   
+            (
+                (match &attentionalFocus ($type $atom $b) ($type $atom $b))
+                (match &attentionalFocus ($type $b $atom) ($type $b $atom))
+            )
+        )  
     )
 )
 

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -153,7 +153,7 @@
 (= (getAfMaxSTI)
     (let $atoms (getAtomList)
         (if (== $atoms ())
-            0
+            0.0
             (getAfMaxSTIHelper $atoms (car-atom $atoms) (getSTI (car-atom $atoms)))
         )
     )

--- a/attention-bank/utilities/helper-functions.metta
+++ b/attention-bank/utilities/helper-functions.metta
@@ -73,11 +73,11 @@
   )
 )
 
-(: size (-> Expression Number))
+;(: size (-> Expression Number))
 (= (size $list)
-   (if (== $list ())
-      0
-      (let $tail (cdr-atom $list) (+ 1 (size $tail)))
+    (if (== $list ())
+        0
+        (+ 1 (size (cdr-atom $list)))
     )
 )
 
@@ -177,6 +177,7 @@
 (= (minList $list)
     (minValue (firstElement $list) $list)
 )
+
 
 ;Function for concatinating
 (= (concatTuple $xs $ys)
@@ -301,34 +302,10 @@
     )
 )
 
-; Helper function to append an element to the end of a list
-(= (append-to-end $list $elem)
-   (if (== $list ()) 
-       (cons-atom $elem ())
-       (let* (
-               ($head (car-atom $list))  
-               ($tail (cdr-atom $list))  
-               ($appended-tail (append-to-end $tail $elem))
-             )
-           (cons-atom $head $appended-tail) 
-       )
-   )
-)
-
 ;function to reverse an expression 
-(= (reverseExpr $expr)
-   (if (== $expr ())
-       ()
-       (let* (
-               ($head (car-atom $expr))  
-               ($tail (cdr-atom $expr))  
-               ($reversed-tail (reverseExpr $tail))  
-               ($result (append-to-end $reversed-tail $head))
-           )
-           $result  
-       )
-   )
-)
+
+(= (reverseExpr $x ) (collapse (union (superpose $x) (superpose ())))) 
+
 
 (: findMaxSTI (-> Expression Number))
 (= (findMaxSTI $list)


### PR DESCRIPTION
I removed unnecessary and redundant code.

Previously, the functions for finding the lowest and maximum STI atoms sorted the lists, which was inefficient. I reimplemented getLowestStiAtomInAF and getAfMaxSTI for better performance.

Additionally, I optimized the reverseExpr function using union and superpose. I also moved unnecessary function calls to an IF block in the updateAttentionalFocus function to prevent unnecessary invocations.