### PR TITLE
Improved recursive structure for finding min and max in helper-function

### DIFF
--- a/attention-bank/utilities/helper-functions.metta
+++ b/attention-bank/utilities/helper-functions.metta
@@ -80,6 +80,7 @@
       (let $tail (cdr-atom $list) (+ 1 (size $tail)))
     )
 )
+(: Max (-> Expression Number))
 ( = (Max $numbers)
   (let* (
     ($top (car-atom $numbers))
@@ -90,9 +91,10 @@
       (let* (
         ($nextTop (car-atom $rest))
         ($tail (cdr-atom $rest))
+        ($mergeList (cons-atom $top $tail))
         )
         (if (> $top $nextTop)
-          (Max (cons-atom $top $tail))
+          (Max $mergeList)
           (Max $rest)
         )
       )
@@ -101,6 +103,7 @@
 
   )
 )
+(: Min (-> Expression Number))
 ( = (Min $numbers)
   (let* (
     ($top (car-atom $numbers))
@@ -111,9 +114,10 @@
       (let* (
         ($nextTop (car-atom $rest))
         ($tail (cdr-atom $rest))
+        ($mergeList (cons-atom $top $tail))
         )
         (if (< $top $nextTop)
-          (Min (cons-atom $top $tail))
+          (Min $mergeList)
           (Min $rest)
         )
       )
@@ -343,6 +347,7 @@
 )
 
 ; a function that find the maximum STI value of the  given atoms
+(: findMaxSTI (-> Expression Number))
 (= (findMaxSTI $list)
   (let* (
     ($atom (car-atom $list))
@@ -355,9 +360,10 @@
         ($nextTop (car-atom $rest))
         ($secondMax (getSTI $nextTop))
         ($tail (cdr-atom $rest))
+        ($mergeList (cons-atom $atom $tail))
         )
         (if (> $max $secondMax)
-          (findMaxSTI (cons-atom $atom $tail))
+          (findMaxSTI $mergeList)
           (findMaxSTI $rest)
         )
       )
@@ -365,6 +371,7 @@
   )
 )
 ; a function that find the minimum STI value of the  given atoms
+(: findMinSTI (-> Expression Number))
 (= (findMinSTI $list)
   (let* (
     ($atom (car-atom $list))
@@ -377,12 +384,15 @@
         ($nextTop (car-atom $rest))
         ($secondMax (getSTI $nextTop))
         ($tail (cdr-atom $rest))
+        ($mergeList (cons-atom $atom $tail))
         )
         (if (< $max $secondMax)
-          (findMinSTI (cons-atom $atom $tail))
+          (findMinSTI $mergeList)
           (findMinSTI $rest)
         )
       )
     )
   )
  )
+
+             

--- a/attention-bank/utilities/helper-functions.metta
+++ b/attention-bank/utilities/helper-functions.metta
@@ -80,35 +80,47 @@
       (let $tail (cdr-atom $list) (+ 1 (size $tail)))
     )
 )
-
-(= (Max $numbers) 
-    (let* (
-        ($max (car-atom $numbers))
-        ($rest (cdr-atom $numbers))
+( = (Max $numbers)
+  (let* (
+    ($top (car-atom $numbers))
+    ($rest (cdr-atom $numbers))
     )
-        (if (not (== $rest ()))
-            (if (> $max (Max $rest))
-                $max
-                (Max $rest)
-            )
-            $max
+    (if (== $rest ())
+      $top
+      (let* (
+        ($nextTop (car-atom $rest))
+        ($tail (cdr-atom $rest))
         )
+        (if (> $top $nextTop)
+          (Max (cons-atom $top $tail))
+          (Max $rest)
+        )
+      )
+    
     )
+
+  )
 )
-
-(= (Min $numbers) 
-    (let* (
-        ($min (car-atom $numbers))
-        ($rest (cdr-atom $numbers))
+( = (Min $numbers)
+  (let* (
+    ($top (car-atom $numbers))
+    ($rest (cdr-atom $numbers))
     )
-        (if (not (== $rest ()))
-            (if (< $min (Min $rest))
-                $min
-                (Min $rest)
-            )
-            $min
+    (if (== $rest ())
+      $top
+      (let* (
+        ($nextTop (car-atom $rest))
+        ($tail (cdr-atom $rest))
         )
+        (if (< $top $nextTop)
+          (Min (cons-atom $top $tail))
+          (Min $rest)
+        )
+      )
+    
     )
+
+  )
 )
  
 ; Recursive helper to calculate the group index

--- a/attention-bank/utilities/helper-functions.metta
+++ b/attention-bank/utilities/helper-functions.metta
@@ -342,38 +342,47 @@
    )
 )
 
-(: findMaxSTI (-> Expression Number))
+; a function that find the maximum STI value of the  given atoms
 (= (findMaxSTI $list)
-   (let*
-     (
-      ($atom (car-atom $list))
-      ($max (getSTI $atom))
-      ($rest (cdr-atom $list))
-      )
-     (if(not (== $rest ()))
-       (if (> $max (findMaxSTI $rest))
-          $max
+  (let* (
+    ($atom (car-atom $list))
+    ($max (getSTI $atom))
+    ($rest (cdr-atom $list))
+    )
+    (if (== $rest ())
+      $max
+      (let* (
+        ($nextTop (car-atom $rest))
+        ($secondMax (getSTI $nextTop))
+        ($tail (cdr-atom $rest))
+        )
+        (if (> $max $secondMax)
+          (findMaxSTI (cons-atom $atom $tail))
           (findMaxSTI $rest)
         )
-       $max
       )
+    )
   )
 )
-
-(: findMinSTI (-> Expression Number))
+; a function that find the minimum STI value of the  given atoms
 (= (findMinSTI $list)
-   (let*
-     (
-      ($atom (car-atom $list))
-      ($min (getSTI $atom))
-      ($rest (cdr-atom $list))
-      )
-     (if(not (== $rest ()))
-       (if (<= $min (findMinSTI $rest))
-          $min
+  (let* (
+    ($atom (car-atom $list))
+    ($max (getSTI $atom))
+    ($rest (cdr-atom $list))
+    )
+    (if (== $rest ())
+      $max
+      (let* (
+        ($nextTop (car-atom $rest))
+        ($secondMax (getSTI $nextTop))
+        ($tail (cdr-atom $rest))
+        )
+        (if (< $max $secondMax)
+          (findMinSTI (cons-atom $atom $tail))
           (findMinSTI $rest)
         )
-       $min
       )
+    )
   )
  )

--- a/attention-bank/utilities/tests/helper-functions-test.metta
+++ b/attention-bank/utilities/tests/helper-functions-test.metta
@@ -2,6 +2,7 @@
 !(import! &self metta-attention:attention-bank:utilities:helper-functions)
 !(import! &self metta-attention:attention-bank:bank:atom-bins:atombins)
 !(import! &self metta-attention:attention-bank:bank:attentional-focus:attentional-focus)
+!(import! &self metta-attention:attention-bank:attention-value:getter-and-setter)
 
 !(assertEqual 
               (filter ((3 (c)) (1 (a)) (37 (f h j k)) (17 (s c)) (18 (g j)) (2 (d)) (27 ())) notEmpty) 
@@ -27,3 +28,19 @@
 !(flatten ((s c) (G E) (a) (g) (f h j k) (d)))
 !(assertEqual(reverseExpr (a b c d)) (d c b a))
 !(assertEqual(reverseExpr ()) ())
+
+;test for the findMaxSTI and findMinSTI functions before that we need to set the values of the atoms
+! (setAv A (300 200 0))
+! (setAv B (200 400 1))
+! (setAv C (100 200 0))
+! (setAv D (600 400 1))
+! (setAv E (200 200 0))
+! (setAv F (800 400 1))
+! (setAv G (50 200 0))
+! (setAv H (900 400 1))
+
+!(findMaxSTI (A B C D E F G H))
+!(assertEqual (findMaxSTI (A B C D E F G H)) 900)
+!(findMinSTI (A B C D E F G H))
+!(assertEqual (findMinSTI (A B C D E F G H)) 50)
+


### PR DESCRIPTION
In the previous implementation of the Max and Min functions, the recursive call within the if condition caused nested recursive calls. Specifically, in this part of the code:
```
(if (> $max (Max $rest)) 
    $max 
    (Max $rest)
)
```
In the worst case, if the array was already sorted, the function would always call Max recursively inside the if statement until the last element, leading to redundant computations and a time complexity of O(n²). Each recursive call would trigger another call, processing the same data multiple times.
I  removed the nested recursion, ensuring that each element is only processed once, which reduced the time complexity to O(n), 