### PR TITLE
Get min max content function update

### DIFF
--- a/attention-bank/bank/atom-bins/get-min-max-content.metta
+++ b/attention-bank/bank/atom-bins/get-min-max-content.metta
@@ -2,7 +2,7 @@
 ; this function take atoms from atombin space and return atoms found inside the largest bin index
 ; it uses Max helper function to get the largest bin index then it returns the atom found in that bin index
 
-
+(: getMaxContent (-> List))
 (= (getMaxContent)
     (let* (
         ($atombin (AtomBin))
@@ -24,7 +24,7 @@
 ; this function take atoms from atombin space and return atoms found inside the smallest bin index
 ; it uses Min helper function to get the smallest bin index then it returns the atom found in that bin index
 
-
+(: getMinContent (-> List))
 (= (getMinContent)
     (let* (
         ($atombin (AtomBin))

--- a/attention-bank/bank/atom-bins/get-min-max-content.metta
+++ b/attention-bank/bank/atom-bins/get-min-max-content.metta
@@ -1,29 +1,46 @@
 
 ; this function take atoms from atombin space and return atoms found inside the largest bin index
 ; it uses Max helper function to get the largest bin index then it returns the atom found in that bin index
-(= (getMaxContent) 
+
+
+(= (getMaxContent)
     (let* (
         ($atombin (AtomBin))
         ($numbers (collapse (match $atombin ($y $x) $y)))
+        )
+    (if (== $numbers ()) (Empty Bin) (
+        let* (
         ($max (max-atom $numbers))
         ($content (match (AtomBin) ($max $x)  $x))
-    )
+        )
+
         $content
     )
+    )
+    )
 )
+
+
 ; this function take atoms from atombin space and return atoms found inside the smallest bin index
 ; it uses Min helper function to get the smallest bin index then it returns the atom found in that bin index
+
+
 (= (getMinContent)
     (let* (
         ($atombin (AtomBin))
         ($numbers (collapse (match $atombin ($y $x) $y)))
+        )
+    (if (== $numbers ()) (Empty Bin) (
+        let* (
         ($min (min-atom $numbers))
         ($content (match (AtomBin) ($min $x)  $x))
-      )
-      $content
+        )
+
+        $content
+    )
+    )
     )
 )
-
 ; this function takes a bin number and return the number of atoms found in that bin
 ; it used size helper function to count the number of atoms found in the bin
 (= (getSize $binNumber)


### PR DESCRIPTION
Updated the getMaxContent and getMinContent Functions to return empty sets when called without inserting atoms to bins