### PR TITLE
Remove the recursion to find getIncomingSet and replace with superpose

### DIFF
--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -288,22 +288,20 @@
 ;;; Parameters:
 ;;;   $incoming_set: A list of incoming links to filter.
 ;;; Returns: A new list containing only the links that are in the AF.
-
 (: filterLinksInAF (-> List List))
 (= (filterLinksInAF $incoming_set)
-    (if (== $incoming_set ())
-        ()
-        (let* (
-              ($head (car-atom $incoming_set))
-              ($tail (cdr-atom $incoming_set))
-              ($filtered_head 
-                    (if (atomIsInAF $head)
-                        $head
-                        ()
-                    ))
-               )
-               
-            (concatTuple ($filtered_head) (filterLinksInAF $tail))
+    (let $atoms (collapse (filterLinksInAFHelper $incoming_set))
+        $atoms
+    )
+)
+; function filterLinksInAFHelper
+; return list of atom that is not in AF
+(: filterLinksInAFHelper (-> List List))
+(= (filterLinksInAFHelper $incoming_set)
+    (let $atom (superpose $incoming_set)
+        (if (atomIsInAF $atom)
+            $atom
+            (emtpy)
         )
     )
 )

--- a/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
+++ b/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
@@ -121,7 +121,6 @@
 
 
 ; Test case 13: Testing getIncomingSet function 
-
 !(assertEqual (getIncomingSet abebe habbianlink) ((habbianlink abebe kebede) (habbianlink challa abebe)))
 
 


### PR DESCRIPTION
Removed recursion  from filterLinksInAF Function and Replaced with the superpose approach.
