### PR TITLE
Fix: AFImportanceDiffusionAgent

### DIFF
--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -1,11 +1,9 @@
 !(bind! &attentionalFocus (new-space))
 !(bind! &newAtomInAV (new-space))
-(= (attentionalFocus)
-    &attentionalFocus
-)
+(= (AttentionalFocus) &attentionalFocus)
 (= (newAtomInAV) &newAtomInAV)
 
-(= (maxAFSize) 100)
+(= (maxAFSize) 1000)
 
 ;Function: atomIsInAF
 ;Description: Checks if a given atom is in the attentional focus space.
@@ -161,18 +159,18 @@
 )
 
 
-; (= (getLowestStiAtomInAFHelper $atoms $minAtom $minSTI) ;; Need to be optimized
-;     (if (== $atoms ())
-;         $minAtom
-;         (let* (
-;             ($current (car-atom $atoms))
-;             ($sti (getSTI $current))
-;             ($newMinAtom (if (< $sti $minSTI) $current $minAtom))
-;             ($newMinSTI (if (< $sti $minSTI) $sti $minSTI))
-;         )
-;         (getLowestStiAtomInAFHelper (cdr-atom $atoms) $newMinAtom $newMinSTI))
-;     )
-; )
+(= (getLowestStiAtomInAFHelper $atoms $minAtom $minSTI)
+    (if (== $atoms ())
+        $minAtom
+        (let* (
+            ($current (car-atom $atoms))
+            ($sti (getSTI $current))
+            ($newMinAtom (if (< $sti $minSTI) $current $minAtom))
+            ($newMinSTI (if (< $sti $minSTI) $sti $minSTI))
+        )
+        (getLowestStiAtomInAFHelper (cdr-atom $atoms) $newMinAtom $newMinSTI))
+    )
+)
 
 ;Function: getLowestStiAtomInAF
 ;Description: Goes through the AF and returns the Atom with the lowest Sti
@@ -184,23 +182,9 @@
     (let $atoms (getAtomList)
         (if (== $atoms ())
             ()
-            ; (getLowestStiAtomInAFHelper $atoms (car-atom $atoms) (getSTI (car-atom $atoms)))
-            (let* 
-                (
-                    ($stiValuesAndAtom (collapse (extractAtomValue (superpose $atoms))))
-                    ($stiValues (collapse (let $temp (superpose $stiValuesAndAtom) (index-atom $temp 0))))
-                    ($minSti (min-atom $stiValues))
-                    ($minAtom (let $temp (superpose $stiValuesAndAtom) 
-                                    (unify ($minSti $atom) $temp $atom (empty))))
-                )
-                    $minAtom
-            )
+            (getLowestStiAtomInAFHelper $atoms (car-atom $atoms) (getSTI (car-atom $atoms)))
         )
     )
-)
-
-(= (extractAtomValue $atom)
-    ((getSTI $atom) $atom)
 )
 
 ;gets the maximum STI value in the attentional focus
@@ -249,7 +233,7 @@
 (= (updateAttentionalFocus $atom)
    (let*
        (
-           ($maxSize (maxAFSize)) 
+           ($maxSize (getAttentionParam MAX_AF_SIZE)) 
            ($sti (getSTI $atom)) 
            ($currentSize (attentionalFocusSize)) 
            ($isInAF (atomIsInAF $atom)) ; Check if atom is already in AF
@@ -506,6 +490,11 @@
         $randomAtom
         )
     )
+)
+
+
+(= (attentionalFocus)
+    &attentionalFocus
 )
 
 

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -1,9 +1,11 @@
 !(bind! &attentionalFocus (new-space))
 !(bind! &newAtomInAV (new-space))
-(= (AttentionalFocus) &attentionalFocus)
+(= (attentionalFocus)
+    &attentionalFocus
+)
 (= (newAtomInAV) &newAtomInAV)
 
-(= (maxAFSize) 1000)
+(= (maxAFSize) 100)
 
 ;Function: atomIsInAF
 ;Description: Checks if a given atom is in the attentional focus space.
@@ -159,18 +161,18 @@
 )
 
 
-(= (getLowestStiAtomInAFHelper $atoms $minAtom $minSTI)
-    (if (== $atoms ())
-        $minAtom
-        (let* (
-            ($current (car-atom $atoms))
-            ($sti (getSTI $current))
-            ($newMinAtom (if (< $sti $minSTI) $current $minAtom))
-            ($newMinSTI (if (< $sti $minSTI) $sti $minSTI))
-        )
-        (getLowestStiAtomInAFHelper (cdr-atom $atoms) $newMinAtom $newMinSTI))
-    )
-)
+; (= (getLowestStiAtomInAFHelper $atoms $minAtom $minSTI) ;; Need to be optimized
+;     (if (== $atoms ())
+;         $minAtom
+;         (let* (
+;             ($current (car-atom $atoms))
+;             ($sti (getSTI $current))
+;             ($newMinAtom (if (< $sti $minSTI) $current $minAtom))
+;             ($newMinSTI (if (< $sti $minSTI) $sti $minSTI))
+;         )
+;         (getLowestStiAtomInAFHelper (cdr-atom $atoms) $newMinAtom $newMinSTI))
+;     )
+; )
 
 ;Function: getLowestStiAtomInAF
 ;Description: Goes through the AF and returns the Atom with the lowest Sti
@@ -182,9 +184,23 @@
     (let $atoms (getAtomList)
         (if (== $atoms ())
             ()
-            (getLowestStiAtomInAFHelper $atoms (car-atom $atoms) (getSTI (car-atom $atoms)))
+            ; (getLowestStiAtomInAFHelper $atoms (car-atom $atoms) (getSTI (car-atom $atoms)))
+            (let* 
+                (
+                    ($stiValuesAndAtom (collapse (extractAtomValue (superpose $atoms))))
+                    ($stiValues (collapse (let $temp (superpose $stiValuesAndAtom) (index-atom $temp 0))))
+                    ($minSti (min-atom $stiValues))
+                    ($minAtom (let $temp (superpose $stiValuesAndAtom) 
+                                    (unify ($minSti $atom) $temp $atom (empty))))
+                )
+                    $minAtom
+            )
         )
     )
+)
+
+(= (extractAtomValue $atom)
+    ((getSTI $atom) $atom)
 )
 
 ;gets the maximum STI value in the attentional focus
@@ -233,7 +249,7 @@
 (= (updateAttentionalFocus $atom)
    (let*
        (
-           ($maxSize (getAttentionParam MAX_AF_SIZE)) 
+           ($maxSize (maxAFSize)) 
            ($sti (getSTI $atom)) 
            ($currentSize (attentionalFocusSize)) 
            ($isInAF (atomIsInAF $atom)) ; Check if atom is already in AF
@@ -493,11 +509,6 @@
 )
 
 
-(= (attentionalFocus)
-    &attentionalFocus
-)
-
-
 (: removeAtomAttentionalfocus (-> atom empty))
 (= (removeAtomAttentionalfocus $atom)
 	(if (atomIsInAF $atom)
@@ -505,5 +516,4 @@
 		()
 	)
 )
-
 

--- a/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
+++ b/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
@@ -1,5 +1,4 @@
 !(register-module! ../../../../../metta-attention)
-!(import! &self metta-attention:attention:agents:mettaAgents:AttentionParam)
 !(import! &self metta-attention:attention-bank:utilities:helper-functions)
 !(import! &self metta-attention:attention-bank:attention-value:getter-and-setter)
 !(import! &self metta-attention:attention-bank:bank:atom-bins:atombins)
@@ -17,7 +16,7 @@
 !(setAv C (200.0 300.0 400.0))
 !(setAv D (25.0 125.0 225.0))
 !(setAv F (70.0 100.0 200.0))
-!(getAttentionParam MAX_AF_SIZE)
+
 ; The test cases were added with setting AV for links but this might not be needed in reality because AVs may not be set for links/expressions
 !(setAv (EvaluationLink a b) (100.0 100.0 100.0))
 !(setAv (Hebbianlink (Hebbianlink Cat Human) Animal) (200.0 250.0 280.0))
@@ -53,7 +52,7 @@
 
 ; Test case 05: Testing getLowestStiAtomInAF returns an atom with lowest Sti
 
-!(assertEqual (getLowestStiAtomInAF) a)
+!(assertEqual (getLowestStiAtomInAF) c)
 
 
 ; Test case 06: Testing updateAttentionalFocus by adding new atom to attentional focus

--- a/attention/agents/mettaAgents/ImportanceDiffusionAgent/AFImportanceDiffusionAgent/AFImportanceDiffusionAgent.metta
+++ b/attention/agents/mettaAgents/ImportanceDiffusionAgent/AFImportanceDiffusionAgent/AFImportanceDiffusionAgent.metta
@@ -10,7 +10,7 @@
         (
             ($atoms (collapse (let $temp (match $space $x $x)
                 (if (== (get-metatype $temp) Expression)
-                    (if (== (car-atom $temp) ASYMMETRIC_HEBBIAN_LINK) 
+                    (if (== (car-atom $temp) ASYMMETRIC_HEBBIAN_LINK)  ;; Needs to be removed
                         (empty)
                         (if (== (car-atom $temp) HEBBIAN_LINK)
                             (empty)
@@ -19,9 +19,8 @@
                     )
                     $temp
                 ))))
-            ($sorted (sortAtomsBySti $atoms))
         )
-        $sorted
+        $atoms
     )
 )
 
@@ -43,7 +42,10 @@
 (: spreadImportance (-> Grounded Grounded Empty))
 (= (spreadImportance $space $space2)
     (let $diffusionSourceVector (diffusionSourceVector $space)
-        (diffuseAtom (superpose $diffusionSourceVector) $space2 AF)
+        (let ($atom $atomToReceive $stiGiven)
+            (diffuseAtom (superpose $diffusionSourceVector) $space2 AF)
+                (tradeSti $atom $atomToReceive $stiGiven)
+            )
     )
 )
 
@@ -56,4 +58,3 @@
 (= (AFImportanceDiffusionAgent-Run $space $space2)
     (spreadImportance $space $space2)
 )
-

--- a/attention/agents/mettaAgents/ImportanceDiffusionAgent/AFImportanceDiffusionAgent/tests/AFImportanceDiffusion-test.metta
+++ b/attention/agents/mettaAgents/ImportanceDiffusionAgent/AFImportanceDiffusionAgent/tests/AFImportanceDiffusion-test.metta
@@ -1,5 +1,4 @@
 !(register-module! ../../../../../../../metta-attention)
-!(import! &self metta-attention:attention:agents:mettaAgents:AttentionParam)
 !(import! &self metta-attention:attention-bank:utilities:helper-functions)
 !(import! &self metta-attention:attention-bank:attention-value:getter-and-setter)
 !(import! &self metta-attention:attention-bank:bank:atom-bins:atombins)
@@ -36,8 +35,8 @@
 
 ;########################## Running the AF Importance Diffusion Agent #############################
 !(AFImportanceDiffusionAgent-Run (attentionalFocus) (TypeSpace))
-
 ;########################## Testing the STI values #############################
+
 !(assertEqual (getSTI source) 6000.0)
 !(assertEqual (getSTI target1) 8000.0)
 !(assertEqual (getSTI target2) 8000.0)
@@ -55,3 +54,26 @@
 !(assertEqual (getSTI (INHERITANCE_LINK source target6)) 1000.0)
 !(assertEqual (getSTI (INHERITANCE_LINK target3 source)) 4200.0)
 !(assertEqual (getSTI (ASYMMETRIC_HEBBIAN_LINK target2 target3)) 0)
+
+; For time purpose commented the below since meTTa is currently slow
+
+; ;########################## Running the AF Importance Diffusion Agent #############################
+; !(AFImportanceDiffusionAgent-Run (attentionalFocus) (TypeSpace))
+; ;########################## Testing the STI values #############################
+; !(assertEqual (getSTI source) 6320.0)
+; !(assertEqual (getSTI target1) 8000.0)
+; !(assertEqual (getSTI target2) 8000.0)
+; !(assertEqual (getSTI target3) 3720.0)
+; !(assertEqual (getSTI target4) 3720.0)
+; !(assertEqual (getSTI target5) 3720.0)
+; !(assertEqual (getSTI target6) 200.0)
+
+; !(assertEqual (getSTI (HEBBIAN_LINK source target1)) 0)
+; !(assertEqual (getSTI (HEBBIAN_LINK source target2)) 0)
+; !(assertEqual (getSTI (ASYMMETRIC_HEBBIAN_LINK source target3)) 0)
+; !(assertEqual (getSTI (INHERITANCE_LINK source target4)) 5040.0)
+; !(assertEqual (getSTI (ASYMMETRIC_HEBBIAN_LINK target1 target2)) 0)
+; !(assertEqual (getSTI (INHERITANCE_LINK source target5)) 5040.0)
+; !(assertEqual (getSTI (INHERITANCE_LINK source target6)) 1200.0)
+; !(assertEqual (getSTI (INHERITANCE_LINK target3 source)) 5040.0)
+; !(assertEqual (getSTI (ASYMMETRIC_HEBBIAN_LINK target2 target3)) 0)

--- a/attention/agents/mettaAgents/ImportanceDiffusionAgent/ImportanceDiffusionBase/ImportanceDiffusionBase.metta
+++ b/attention/agents/mettaAgents/ImportanceDiffusionAgent/ImportanceDiffusionBase/ImportanceDiffusionBase.metta
@@ -41,10 +41,7 @@
                     )
             )
         )
-        (if (== $atomToReceive ())
-            ()
-            (tradeSti $atom $atomToReceive $stiGiven)
-        )
+        ($atom $atomToReceive $stiGiven)
     )
 )
 
@@ -59,7 +56,7 @@
         (
             ($incomingSet (getAllIncomingSets $atom $space))
             ($filtered
-                (if (== (car-atom $incomingSet) ASYMMETRIC_HEBBIAN_LINK)
+                (if (== (car-atom $incomingSet) ASYMMETRIC_HEBBIAN_LINK) ;; Need to be Removed
                     (empty)
                     (if (== (car-atom $incomingSet) HEBBIAN_LINK)
                         (empty)

--- a/attention/agents/mettaAgents/ImportanceDiffusionAgent/WAImportanceDiffusionAgent/WAImportanceDiffusionAgent.metta
+++ b/attention/agents/mettaAgents/ImportanceDiffusionAgent/WAImportanceDiffusionAgent/WAImportanceDiffusionAgent.metta
@@ -12,14 +12,11 @@
                 (if (== $atoms ())
                     ()
                     (if (== (get-metatype $atoms) Expression)
-                            (if (== (car-atom $atoms) ASYMMETRIC_HEBBIAN_LINK)
-                                (empty)
-                                (if (== (car-atom $atoms) HEBBIAN_LINK)
-                                    (empty)
-                                    $atoms
-                                )
-                            )
+                        (if (== (car-atom $atoms) HEBBIAN_LINK)
+                            (empty)
                             $atoms
+                        )
+                        $atoms
                     )
                 )
             )


### PR DESCRIPTION
Fixed the problem with AFImportanceDiffusionAgent that in second iteration it was causing different result than the C++. The problem was logical, In the previous implementation I made the STI trade on each iteration which was wrong. Now I made it tradeSTI after all probability is calculated.

Made Some optimizations such as using builtin functions and also remove sort from DiffusionSourceVector since there is no need for it.