### PR TITLE
Fix/afdiffuionbracket

### DIFF
--- a/attention/agents/mettaAgents/ImportanceDiffusionAgent/ImportanceDiffusionBase/ImportanceDiffusionBase.metta
+++ b/attention/agents/mettaAgents/ImportanceDiffusionAgent/ImportanceDiffusionBase/ImportanceDiffusionBase.metta
@@ -30,7 +30,7 @@
             )
             (($atomToReceive $stiGiven)
                     (if (== $totaldiffusionAmount 0)
-                        (() 0)
+                        (empty)
                         (let*
                             (
                                 (($first $second) (superpose $combProbabilityVector))

--- a/attention/agents/mettaAgents/ImportanceDiffusionAgent/ImportanceDiffusionBase/ImportanceDiffusionBase.metta
+++ b/attention/agents/mettaAgents/ImportanceDiffusionAgent/ImportanceDiffusionBase/ImportanceDiffusionBase.metta
@@ -30,7 +30,7 @@
             )
             (($atomToReceive $stiGiven)
                     (if (== $totaldiffusionAmount 0)
-                        (empty)
+                        (() 0)
                         (let*
                             (
                                 (($first $second) (superpose $combProbabilityVector))
@@ -245,7 +245,9 @@
 
 (: tradeSti (-> Atom Atom Number %Undefined%))
 (= (tradeSti $source $target $value)
-      (let*
+    (if (or (== $source ()) (== $target ()))
+        ()
+        (let*
             (
                 ($sourceSTI (getSTI $source))
                 ($targetSTI (getSTI $target))
@@ -254,6 +256,7 @@
                 (() (setSTI $target $newTargetSTI))
                 (() (setSTI $source $newSourceSTI))
             )
-        ()
+            ()
+        )
     )
 )


### PR DESCRIPTION
this pull request adds an if check on tradesti to avoid situation where the diffuse atom function return (() 0) to tradesti which will create a new atom with () and av value (0 0 0)