### PR TITLE
change hebupdating getRandomAtomNotInAF -> getRandomAtomInAF

### DIFF
--- a/attention/agents/mettaAgents/HebbianUpdatingAgent/HebbianUpdatingAgent.metta
+++ b/attention/agents/mettaAgents/HebbianUpdatingAgent/HebbianUpdatingAgent.metta
@@ -13,7 +13,7 @@
     (let $atoms (getAtomList)
         (if (== $atoms ())
             ()
-            (let $randomAtom (getRandomAtomNotInAF)
+            (let $randomAtom (getRandomAtomInAF)
                 (updateHebbianLinks $randomAtom $space)
             )
         )


### PR DESCRIPTION
this pull request changes the hebbiaupdating agent to use random atom from the af rather than out of the af