### PR TITLE
change of atom removal so that we dont have multiple () bins

### DIFF
--- a/attention-bank/bank/atom-bins/atombins.metta
+++ b/attention-bank/bank/atom-bins/atombins.metta
@@ -78,7 +78,12 @@
                      (let*
                        (
                           ($atomremove (remove-atom &atombin ($bin_index $x)))
-                          ($atomadded (add-atom &atombin ($bin_index $updated_contents)))
+                          ($atomadded 
+                            (if (== $updated_content ())
+                                ()
+                                (add-atom &atombin ($bin_index $updated_contents))
+                            )
+                          )
                         )
                      ("Atom Removed")
                      )


### PR DESCRIPTION
this pull request changes the logic of the atombins removeAtom to enable it to not create empty bins when a bin with only one atom is removes the atom