### PR TITLE
Fix/forgetting agent

### DIFF
--- a/attention-bank/attention-value/getter-and-setter.metta
+++ b/attention-bank/attention-value/getter-and-setter.metta
@@ -292,3 +292,10 @@
 (= (getAtomsInTypeSpace) 
 	(collapse (getAtomsInTypeSpace-helper))
 )
+
+(= (countAtomsInTypeSpace)
+    (let $atoms
+        (getAtomsInTypeSpace)
+        (size-atom $atoms)
+    )
+)

--- a/attention-bank/bank/atom-bins/atombins.metta
+++ b/attention-bank/bank/atom-bins/atombins.metta
@@ -78,7 +78,12 @@
                      (let*
                        (
                           ($atomremove (remove-atom &atombin ($bin_index $x)))
-                          ($atomadded (add-atom &atombin ($bin_index $updated_contents)))
+                          ($atomadded 
+                            (if (== $updated_content ())
+                                ()
+                                (add-atom &atombin ($bin_index $updated_contents))
+                            )
+                          )
                         )
                      ("Atom Removed")
                      )

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -53,7 +53,11 @@
        (let* 
             (
                 (() (add-atom &attentionalFocus $atom))
-                (() (add-atom &newAtomInAV $atom))
+                (() (if (contains (getNewAtomInAVList) $atom)
+                        ()
+                        (add-atom &newAtomInAV $atom)
+                    )
+                )
             )
             ("Atom Added")
         )
@@ -485,3 +489,7 @@
 )
 
 
+;(: removeNewAtomAV (-> atom empty))
+(= (removeNewAtomAV $head)
+    (remove-atom &newAtomInAV $head)
+)

--- a/attention/agents/mettaAgents/ForgettingAgent/ForgettingAgent.metta
+++ b/attention/agents/mettaAgents/ForgettingAgent/ForgettingAgent.metta
@@ -215,6 +215,7 @@
 (= (globalRemoveAtom $head $niset) 
 	(let*
 		(
+            (() (refundAV $head))
 			(() (add-atom &removeSpace (: $head ((STV 0.0 0.0) (AV 0.0 0.0 0.0)))))
 			(() (extractAtomRecursive $niset))
 			(() (removeAtomAttentionalfocus $head))
@@ -240,6 +241,7 @@
 			(
 				($head (car-atom $atoms))
 				($tail (cdr-atom $atoms))
+                (() (refundAV $head))
 				(() (add-atom &removeSpace (: $head ((STV 0.0 0.0) (AV 0.0 0.0 0.0)))))
 				($bin (importanceBin (getSTI $head)))
 				($_ (removeAtom $bin $head))
@@ -251,6 +253,17 @@
 	)
 )
 
+; Description: a function that sets atoms STI and LTI to zero prior to removal to insure its funds are returned
+; params:
+;   $atom: atom whose value is set to zero
+; return: empty
+(: refundAV (-> Atom empty))
+(= (refundAV $atom)
+    (if (== (getAv $atom) %Undefined%)
+        ()
+        (setAv $atom (0 0 0))
+    )
+)
 ; Description: a wrapper for getRemoveValueType-helper it collapses the result and retunrs undefined or value type
 ; params:
 ;	$pattern: an atom whose attention and truth value to be searched

--- a/attention/agents/mettaAgents/ForgettingAgent/ForgettingAgent.metta
+++ b/attention/agents/mettaAgents/ForgettingAgent/ForgettingAgent.metta
@@ -217,12 +217,12 @@
 		(
             (() (refundAV $head))
 			(() (add-atom &removeSpace (: $head ((STV 0.0 0.0) (AV 0.0 0.0 0.0)))))
+            (() (removeNewAtomAV $head))
 			(() (extractAtomRecursive $niset))
 			(() (removeAtomAttentionalfocus $head))
 			($bin (importanceBin (getSTI $head)))
 			($_ (removeAtom $bin $head))
 			(() (removeTypeSpace $head))
-
 		)
 		()
 	)
@@ -247,6 +247,7 @@
 				($_ (removeAtom $bin $head))
 				(() (removeAtomAttentionalfocus $head))
 				(() (removeTypeSpace $head))
+                (() (removeNewAtomAV $head))
 			)
 			(extractAtomRecursive $tail)
 		)

--- a/attention/agents/mettaAgents/ForgettingAgent/ForgettingAgent.metta
+++ b/attention/agents/mettaAgents/ForgettingAgent/ForgettingAgent.metta
@@ -19,7 +19,7 @@
 		(
 			($count 0)
 			($atoms (collapseBin $space))
-			($size (size-atom $atoms)) 
+			($size (countAtomsInTypeSpace)) 
 			($removalAmount (- $size (- (maxSize) (accDivSize))))
 			($filteredatom (filterByLti $atoms))
 			($sortedatoms (ForgettingLTIThenTVAscendingSort $filteredatom))

--- a/attention/agents/mettaAgents/ForgettingAgent/tests/ForgettingAgent-test.metta
+++ b/attention/agents/mettaAgents/ForgettingAgent/tests/ForgettingAgent-test.metta
@@ -80,6 +80,7 @@
 ; stv &av, lit < 5, source < 5, target < 5, link lti above source & target lti
 !(stimulate (SYMMETRIC_HEBBIAN_LINK M N) 0.2)
 
+!(assertEqual (match &space (fundsSTI $x) $x) 99174.80000000002)
 
 
 !(forgettingAgent-Run (AtomBin))
@@ -94,5 +95,6 @@
     ) 
     ()
 )
+!(assertEqual (match &space (fundsSTI $x) $x) 99468.40000000002)
 
 !(assertEqual (let $a (getAtomsInRemoveSpace) (size-atom $a)) 16)

--- a/attention/agents/mettaAgents/ForgettingAgent/tests/ForgettingAgent-test.metta
+++ b/attention/agents/mettaAgents/ForgettingAgent/tests/ForgettingAgent-test.metta
@@ -85,16 +85,18 @@
 
 !(forgettingAgent-Run (AtomBin))
 
-!(assertEqual 
-    (let*
-        (
-            ($rmvspace (getAtomsInRemoveSpace))	
-            ($typspace (getAtomsInTypeSpace))
-        )
-        (intersection-atom $typspace $rmvspace)
-    ) 
+
+!(let*
+    (
+        ($rmvspace (getAtomsInRemoveSpace))	
+        ($typspace (getAtomsInTypeSpace)) 
+        ($newAtomInAV (getNewAtomInAVList))
+        ($assertTypespace (assertEqual (intersection-atom $typspace $rmvspace) ()))
+        ($assertNewtoAvspace (assertEqual (intersection-atom $newAtomInAV $rmvspace) ()))
+    )
     ()
-)
+) 
+
 !(assertEqual (match &space (fundsSTI $x) $x) 99468.40000000002)
 
 !(assertEqual (let $a (getAtomsInRemoveSpace) (size-atom $a)) 16)


### PR DESCRIPTION
this pull request makes the following change in the forgetting agent
1. it changes the size calulations to be based on the size of typespace than size of atombin
reason for change
the main reason for change was identified by running the agents together which showed in the following secnario

(10 (a) 8 (b) 4(c) 3 (d)) -> Atombin
(a b c d (Asymetric_H..... a b) (Asy...link b a) (Asy...link a c).....) -> type space

in the above secnario both atoms c and d along with their asymettic links must be removed but without this change the process end early due to it removeing the atom d and its asymetic links which are more than a calcucalted value which will be 3 in this case

2. it makes changes so that atoms in the newAtomAv space are not duplicated
3. it ensured funds are returned
4. it adds tests for the above cases