### PR TITLE
find Group optimized using general formula

### DIFF
--- a/attention-bank/utilities/helper-functions.metta
+++ b/attention-bank/utilities/helper-functions.metta
@@ -87,9 +87,21 @@
  
 ; Recursive helper to calculate the group index
 (= (findGroup $imp $sum $i)
-   (if (or (>= $sum $imp) (>= $i (GroupNum)))
-       $i
-       (findGroup $imp (+ $sum (pow-math 2 $i)) (+ $i 1))
+   (if ( <= $imp 0)
+    0
+    (
+        let* (
+            ($num (+ $imp 1))
+            ($log_num (log-math 2 $num))
+            ($int_num (ceil-math $log_num))
+            
+        )
+        
+        (if (<= $int_num (GroupNum))
+            $int_num
+            (GroupNum)
+        )
+    )
    )
 )
 

--- a/attention-bank/utilities/tests/helper-functions-test.metta
+++ b/attention-bank/utilities/tests/helper-functions-test.metta
@@ -3,6 +3,7 @@
 !(import! &self metta-attention:attention-bank:bank:atom-bins:atombins)
 !(import! &self metta-attention:attention-bank:bank:attentional-focus:attentional-focus)
 !(import! &self metta-attention:attention-bank:attention-value:getter-and-setter)
+!(import! &self metta-attention:attention-bank:bank:importance-index:importance-index)
 
 !(assertEqual 
               (filter ((c)(a)(f h j k)(s c)(g j)(d)()) notEmpty) 
@@ -28,6 +29,16 @@
 !(flatten ((s c) (G E) (a) (g) (f h j k) (d)))
 !(assertEqual(reverseExpr (a b c d)) (d c b a))
 !(assertEqual(reverseExpr ()) ())
+
+!(assertEqual (findGroup 0 0 0) 0)
+!(assertEqual (findGroup 1 0 0) 1)
+!(assertEqual (findGroup 2 0 0) 2)
+!(assertEqual (findGroup 3 0 0) 2)
+!(assertEqual (findGroup 4 0 0) 3)
+
+!(assertEqual (findGroup 50 0 0) 6)
+!(assertEqual (findGroup 500 0 0) 9)
+!(assertEqual (findGroup 5000 0 0) 12)
 
 
 


### PR DESCRIPTION
Original Loop Implementation
```
int sum = 0;
int i = 0;
for (i = 0; i <= MAX; i++) {
    if (sum >= imp)
        break;
    sum += std::pow(2, i);
}
```
`This is equivalent to computing the geometric sum: Sn = 1 + 2 + 4 + 8 + ... + 2^n = 2^(n+1) - 1`
 Closed-form Formula
the ration of the geometric sequence always 2

> `r = 2`
> S1 = 1 this always starting point for the sequence 
> `our target is to find i or n`
> `Si = 2^(i + 1) - 1 find i`
> our imp variable is the target so we sum untile the summation equal to or  greater than imp
> `Si == imp`
> `imp <= 2^(n + 1) -1`
> `n = ceil(log2(imp + 1) - 1)`

> last base case if n is greater than GroupNumper we just return GroupNumber 
`GroupNumber = 12`