### PR TITLE
Fix/hebcreation

### DIFF
--- a/attention-bank/bank/attention-bank.metta
+++ b/attention-bank/bank/attention-bank.metta
@@ -112,7 +112,7 @@
          ($two (updateSTIFunds $oldSTIFund $newSTIFund))
          ($atombin (AtomBin))
          ($r (update $atombin))
-         ($three (updateAttentionalFocus $pattern))
+         ($three (updateAttentionalFocus $pattern True))
         )
         $r
     )

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -58,7 +58,7 @@
                         ()
                         (if $new
                             (add-atom &newAtomInAV $atom)
-                            (println! $new)
+                            ()
                         )
                     )
                 )

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -43,11 +43,12 @@
 ;Description:
 ;           if the atom has neither AV nor STV,it returns an error message
 ;           if an atom is valid,it will add it to the attentional focus space. 
+;           if an atom is new to the AF and isnt in newAtomIAV 
 ;Parameters:
 ;          $atom: The atom to add.
 ;Returns: A message indicating success or failure.
-(: addAtomToAF (-> Atom Symbol))
-(= (addAtomToAF $atom)
+(: addAtomToAF (-> Atom Bool Symbol))
+(= (addAtomToAF $atom $new)
    (if (== (getValueType $atom) %Undefined%)
        ("Atom is not valid")
        (let* 
@@ -55,7 +56,10 @@
                 (() (add-atom &attentionalFocus $atom))
                 (() (if (contains (getNewAtomInAVList) $atom)
                         ()
-                        (add-atom &newAtomInAV $atom)
+                        (if $new
+                            (add-atom &newAtomInAV $atom)
+                            (println! $new)
+                        )
                     )
                 )
             )
@@ -210,8 +214,8 @@
 ;Parameters:
 ;          $atom: The atom to be added or updated.
 ;Returns: Nothing if no update occurs, otherwise the atom is added.
-(: updateAttentionalFocus (-> Atom empty))
-(= (updateAttentionalFocus $atom)
+(: updateAttentionalFocus (-> Atom Bool empty))
+(= (updateAttentionalFocus $atom $newAtom)
    (let*
        (
         
@@ -225,16 +229,16 @@
            ; Case 1: Atom is already in AF, update its value
            (let ()
                (remove-atom &attentionalFocus $atom)
-               (addAtomToAF $atom)
+               (addAtomToAF $atom $newAtom)
            )
            (if (< $currentSize $maxSize)
                ; Case 2: AF is not full, add the new atom
-               (addAtomToAF $atom)
+               (addAtomToAF $atom $newAtom)
                (let $lowestAtom (getLowestStiAtomInAF) ; Only compute if needed
                     (if (> $sti (getSTI $lowestAtom))  ; Case 3: Replace if better
                         (let ()
                             (remove-atom &attentionalFocus $lowestAtom)
-                            (addAtomToAF $atom)
+                            (addAtomToAF $atom True)
                         )
                         () ; Case 4: Atom not added
                     )

--- a/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
+++ b/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
@@ -59,19 +59,19 @@
 ; Test case 06: Testing updateAttentionalFocus by adding new atom to attentional focus
 
 !(setAv G (300.0 400.0 500.0))
-!(assertEqual (updateAttentionalFocus G) ("Atom Added"))
+!(assertEqual (updateAttentionalFocus G True) ("Atom Added"))
 !(assertEqual (getAtomList) (a d c A B C D F (EvaluationLink a b) (Hebbianlink (Hebbianlink Cat Human) Animal) G))
 
 
 ; Test case 07: Testing updateAttentionalFocus by changing values of saved atom
 
 !(setAv G (15.0 25.0 35.0))
-!(assertEqual (updateAttentionalFocus G) ("Atom Added"))
+!(assertEqual (updateAttentionalFocus G True) ("Atom Added"))
 !(assertEqual (getAtomList) (a d c A B C D F (EvaluationLink a b) (Hebbianlink (Hebbianlink Cat Human) Animal) G))
 
 ; Test case 08: Testing updateAttentionalFocus adding an atom without AV 
 
-!(assertEqual (updateAttentionalFocus L) ("Atom is not valid"))
+!(assertEqual (updateAttentionalFocus L True) ("Atom is not valid"))
 ; !(assertEqual (getAtomList) (a A B C D F G))
 
 

--- a/attention/agents/mettaAgents/HebbianCreationAgent/HebbianCreationAgent.metta
+++ b/attention/agents/mettaAgents/HebbianCreationAgent/HebbianCreationAgent.metta
@@ -44,7 +44,7 @@
                                 (removeLinkRecursively (- (size-atom $incomingSet) maxLinkNum))
                                 ()
                             )
-                            (add-atom $space2 $source)
+                            (updateAttentionalFocus $source False)
                         )
                     )
                 )

--- a/attention/agents/mettaAgents/HebbianCreationAgent/HebbianCreationAgentTest/HebbianCreationAgentC++-test.metta
+++ b/attention/agents/mettaAgents/HebbianCreationAgent/HebbianCreationAgentTest/HebbianCreationAgentC++-test.metta
@@ -70,7 +70,7 @@
     (let $atoms (collapse 
                     (match (TypeSpace) (: (ASYMMETRIC_HEBBIAN_LINK $x $y) $value) 
                             (ASYMMETRIC_HEBBIAN_LINK $x $y))) (size-atom $atoms))
-    20
+    12
 )
 
 !(assertEqual (collapse ("After The Hebbian Creation " (get-atoms (newAtomInAV)))) ())

--- a/attention/agents/mettaAgents/HebbianCreationAgent/HebbianCreationAgentTest/HebbianCreationAgentC++-test.metta
+++ b/attention/agents/mettaAgents/HebbianCreationAgent/HebbianCreationAgentTest/HebbianCreationAgentC++-test.metta
@@ -10,6 +10,7 @@
 !(import! &self metta-attention:attention:agents:mettaAgents:Neighbors)
 !(import! &self metta-attention:attention:agents:mettaAgents:HebbianCreationAgent:HebbianCreationAgent)
 
+!(updateAttentionParam MAX_AF_SIZE 4)
 !(bind! conf90 900)
 ; Populate the AtomSpace with the example atoms
 
@@ -63,7 +64,7 @@
 
 ;;Confirm that only n*(n-1) = 12 AsymmetricHebbianLinks were formed,
 ;;indicating that none incorrectly include "slimy" nor the dummy atoms
-!(assertEqual (attentionalFocusSize) 5)
+!(assertEqual (attentionalFocusSize) 4)
 
 !(assertEqual   
     (let $atoms (collapse 


### PR DESCRIPTION
This pull requests solves the issue #118 of hebbian creation violating max af size

1. it does this by using updateAttentionalfocus which manages the attentional focus than adding atom directly to the space
2. it adds a boolean to the updateAttnetinalfocus function whcih controls if the atom should also be added to the newtoavspace to ensure hebbian creation does not insert atoms to the newatominav.
3. added and modified tests on hebrian creation and attentional-focus.