### PR TITLE
Fix/lowest atom

### DIFF
--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -201,7 +201,7 @@
     (let $atoms (getAtomList)
         (if (== $atoms ())
             ()
-            (getLowestStiAtomInAFHelper $atoms (car-atom $atoms) (getSTI (car-atom $atoms)))
+            (let $atom (car-atom $atoms) (getLowestStiAtomInAFHelper $atoms (car-atom $atoms) (getSTI $atom)))
         )
     )
 )

--- a/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
+++ b/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
@@ -53,7 +53,7 @@
 
 ; Test case 05: Testing getLowestStiAtomInAF returns an atom with lowest Sti
 
-!(assertEqual (getLowestStiAtomInAF) a)
+!(assertEqual (getLowestStiAtomInAF) c)
 
 
 ; Test case 06: Testing updateAttentionalFocus by adding new atom to attentional focus


### PR DESCRIPTION
this pull request changes the function for finding the lowest atom int the AF
1. the functions now uses let to evaulate car-atom before calling getSTI on the first atom in the list
2. it changes the test for the function which now correctly returns the atom with the lowest sti value