### PR TITLE
Clean/attentional focuss

### DIFF
--- a/attention-bank/bank/attention-bank.metta
+++ b/attention-bank/bank/attention-bank.metta
@@ -99,7 +99,7 @@
          ($two (updateAttentionParam FUNDS_LTI $newLTIFund))
          ($atombin (AtomBin))
          ($r (update $atombin))
-         ($three (updateAttentionalFocus $pattern True))
+         ($three (updateAttentionalFocus $pattern))
         )
         $r
     )

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -45,10 +45,10 @@
 ;Parameters:
 ;          $atom: The atom to add.
 ;Returns: A message indicating success or failure.
-(: addAtomToAF (-> Atom Symbol))
+(: addAtomToAF (-> Atom Bool))
 (= (addAtomToAF $atom)
    (if (== (getValueType $atom) %Undefined%)
-       ("Atom is not valid")
+       False
        (let* 
             (
                 (() (add-atom &attentionalFocus $atom))
@@ -61,7 +61,7 @@
                     )
                 )
             )
-            ("Atom Added")
+            True
         )
    )
 )
@@ -135,7 +135,7 @@
 ;Parameters:
 ;          $atom: The atom to be added or updated.
 ;Returns: Nothing if no update occurs, otherwise the atom is added.
-(: updateAttentionalFocus (-> Atom empty))
+(: updateAttentionalFocus (-> Atom ()))
 (= (updateAttentionalFocus $atom)
    (let*
        (
@@ -256,9 +256,14 @@
     )
 )
 
+;;; Function: getRandomAtomInAF
+;;; Descriptions: Retrives at atom at random from the attentionalFocus
+;;; Parameters: None
+;;; Returns: A unit Atom in Af is empty or a random atom 
+(: getRandomAtomInAF (-> Atom))
 ( = (getRandomAtomInAF)
     (if  (== (attentionalFocusSize) 0)
-        ("AF is Empty")
+        ()
         ;else
         ( let*( ($randomNumber (random-int 0 (attentionalFocusSize) ))
             ($atoms (getAtomList))
@@ -270,7 +275,11 @@
 )
 
 
-
+;;; Function: removeAtomAttentionalfocus
+;;; Description: removes an atom from the attentionalFocus space
+;;; Parameters:
+;;;     $atom: The atom to be removed from AF
+;;; Returns: A unit-atom
 (: removeAtomAttentionalfocus (-> atom empty))
 (= (removeAtomAttentionalfocus $atom)
 	(if (atomIsInAF $atom)
@@ -279,8 +288,12 @@
 	)
 )
 
-
-;(: removeNewAtomAV (-> atom empty))
+;;; Function: removeNewAtomAv
+;;; Description: removes an atom from the newAtonInAv space
+;;; Parameters:
+;;;     $atom: The atom to be removed from AF
+;;; Returns: A unit-atom
+(: removeNewAtomAV (-> atom ()))
 (= (removeNewAtomAV $head)
     (remove-atom &newAtomInAV $head)
 )

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -445,26 +445,6 @@
 )
 
 
-;;; Function: getIncomingSetwithoutType
-;;; Description: Retrieves the set of incoming links for a given atom,
-;;;              without filtering out links not in the attentional focus (AF).
-;;; Parameters:
-;;;   $atom: The atom for which to find incoming links.
-;;; Returns: A list of incoming links.
-(: getIncomingSetwithoutType (-> Atom List))
-(= (getIncomingSetwithoutType $atom)
-    (collapse
-        (superpose
-            (
-                (match &attentionalFocus ($type $atom $b) ($type $atom $b))
-                (match &attentionalFocus  ($type $b $atom) ($type $b $atom))
-            )
-        )  
-    )
-)
-
-
-
 ( = (getRandomAtomInAF)
     (if  (== (attentionalFocusSize) 0)
         ("AF is Empty")

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -1,9 +1,7 @@
 !(bind! &attentionalFocus (new-space))
 !(bind! &newAtomInAV (new-space))
-(= (AttentionalFocus) &attentionalFocus)
+(= (attentionalFocus) &attentionalFocus)
 (= (newAtomInAV) &newAtomInAV)
-
-(= (maxAFSize) 1000)
 
 ;Function: atomIsInAF
 ;Description: Checks if a given atom is in the attentional focus space.
@@ -95,83 +93,6 @@
    (let $atomList (getAtomList)
     (size-atom $atomList)
    )
-)
-
-;Function: lessThanSti
-;Description: Helper function that checks if the STI of $elem is less than the STI of $pivot.
-;Parameters:
-;         $elem: The first atom.
-;         $pivot: The atom to compare against.
-;Returns: True if $elem has a lower STI than $pivot, otherwise False.
-(: lessThanSti (-> Atom Atom Bool))
-(= (lessThanSti $elem $pivot)
-    (if (or (== $elem ()) (== $pivot ())) 
-        False 
-        (< (getSti $elem) (getSti $pivot))
-    )
-)
-
-;Function: greaterEqualSti
-;Description: Helper function that checks if the STI of $elem is greater than or equal to the STI of $pivot.
-;Parameters:
-;        $elem: The first atom.
-;        $pivot: The atom to compare against.
-;Returns: True if $elem has an equal or higher STI than $pivot, otherwise False.
-
-
-(: greaterEqualSti (-> Atom Atom Bool))
-(= (greaterEqualSti $elem $pivot)
-    (if (or (== $elem ()) (== $pivot ())) 
-        False 
-        (>= (getSti $elem) (getSti $pivot))
-    )
-)
-
-;Function: sortAtomsBySti
-;Description: Sorts a list of atoms by their STI values in ascending order using recursive filtering.
-;Parameters:
-;         $atoms: A list of atoms.
-;Returns: A sorted list of atoms in ascending order of STI.
-
-(: sortAtomsBySti (-> Symbol Symbol))
-(= (sortAtomsBySti $atoms)
-    (if (== $atoms ())
-        ()
-        (let*
-           (
-               ($pivot (car-atom $atoms))
-               ($tail (cdr-atom $atoms))
-               ($lesser (binaryFilter lessThanSti $pivot $tail))
-               ($greater (binaryFilter greaterEqualSti $pivot $tail))
-               ($sortedLesser (sortAtomsBySti $lesser))
-               ($sortedGreater (sortAtomsBySti $greater))
-           )
-           (concatTuple $sortedLesser (cons-atom $pivot $sortedGreater))
-        )
-    )
-)
-
-;Function: sortAtomsByStiDescending
-;Description:Sorts a list of atoms by their STI values in descending order using recursive filtering.
-;Parameters:
-;         $atoms: A list of atoms.
-;Returns: A sorted list of atoms in descending order of STI.
-(: sortAtomsByStiDescending (-> Symbol Symbol))
-(= (sortAtomsByStiDescending $atoms)
-    (if (== $atoms ())
-        ()
-        (let*
-           (
-               ($pivot (car-atom $atoms))
-               ($tail (cdr-atom $atoms))
-               ($greater (binaryFilter greaterEqualSti $pivot $tail))
-               ($lesser (binaryFilter lessThanSti $pivot $tail))
-               ($sortedGreater (sortAtomsByStiDescending $greater))
-               ($sortedLesser (sortAtomsByStiDescending $lesser))
-           )
-           (concatTuple $sortedGreater (cons-atom $pivot $sortedLesser))
-        )
-    )
 )
 
 
@@ -335,116 +256,6 @@
     )
 )
 
-
-;This function simply matches if two nodes are equal and they are in AF
-(:nodeMatch (-> Atom Atom Bool))
-(= (nodeMatch $node1 $node2)
-    (if (and (== $node1 $node2) (atomIsInAF $node2))
-        True
-        False
-    )
-)
-
-
-
-
-
-; Function: tuple-count
- ; Description: Calculates the tuple-count of a tuple.
- ; Parameters:
- ;   - $tuple: The tuple whose tuple-count is to be calculated.
- ; Returns:
- ;   - The tuple-count of the tuple as an integer.
- ;; Count the number elements in an expression
-
- ;; this Function is copied from the pattern minor project found at https://github.com/iCog-Labs-Dev/hyperon-miner/blob/experiments/experiments/utils/common-utils.metta
-
-   (: tupleCount (-> %Undefined% Number))
-   (= (tupleCount $atom) (if (== $atom ()) 0 (+ 1 (tupleCount (cdr-atom $atom)))))
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
- ;;(: getArity (-> $pattern) Number)
- ;; we substruct 1 since the getArity count the all tuple and we don't want to count
- ;; the "AND LINK" as a part of the arity
-
- ;; this Function is copied from the pattern minor project found at https://github.com/iCog-Labs-Dev/hyperon-miner/blob/experiments/experiments/utils/common-utils.metta
-
-
-(= (getArity $pattern)
-	(if (== $pattern ())
-		0
-	    (- (tupleCount $pattern) 1)
-	) 
-)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
- ; Function: getVariables
- ; This function extracts all the variables from a given pattern (Expression).
- ; It works recursively by checking each element of the pattern to see if it is of the metatype "Variable".
-; this funtion is required because it is called by the termMatchMixinLinkMatch function
- ; Parameters:
- ;   - $pattern: The pattern from which to extract the variables.
- ; Returns:
- ;   - A list of all the variables in the pattern.
-
-(= (getVariables $pattern)
-    (if (== $pattern ())
-        ()
-        (if (== (let* (
-                        ($var (car-atom $pattern)))
-                    (get-metatype $var)) Variable)
-            ( (car-atom $pattern) (getVariables (cdr-atom $pattern)))
-            (getVariables (cdr-atom $pattern))
-        ))
-)
-
-
-(: termMatchMixinLinkMatch ( -> Atom Atom Bool))
-
-(= (termMatchMixinLinkMatch $ptm $lsoln)
-    (if (== $ptm $lsoln)
-        True
-        (if (== (car-atom $ptm) CHOICE_LINK)  
-            True
-            (if (not (== (car-atom $ptm) (car-atom $lsoln)))
-                False
-                ;else
-                (let* (( $ptmArity (getArity $ptm))
-                       ( $lsolnArity (getArity $lsoln)))
-                    (if (not (== $ptmArity $lsolnArity))
-                        False
-                        ;else
-                        (if (== (car-atom $ptm) SCOPE_LINK)
-                            (if (not (== (getVariables $ptm) (getVariables $lsoln)))
-                                False
-                                True)
-                            True)
-                    )
-                )
-            )
-        )
-    )
-)
-
-
-
-
-
-
-; This function matches if the link matches the TermMatchMixin condition and is in The attentional focus.It is a function that is currently found in the opencog atomspace repository(https://github.com/opencog/atomspace/blob/master/opencog/query/TermMatchMixin.cc).
-
-( :linkMatch(-> Atom Atom Bool))
-( = (linkMatch $ptm $lsoln)
-    (if (and (termMatchMixinLinkMatch $ptm $lsoln) (atomIsInAF $lsoln))
-    True
-    False
-    )
-)
-
-
 ( = (getRandomAtomInAF)
     (if  (== (attentionalFocusSize) 0)
         ("AF is Empty")
@@ -458,10 +269,6 @@
     )
 )
 
-
-(= (attentionalFocus)
-    &attentionalFocus
-)
 
 
 (: removeAtomAttentionalfocus (-> atom empty))

--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -47,8 +47,8 @@
 ;Parameters:
 ;          $atom: The atom to add.
 ;Returns: A message indicating success or failure.
-(: addAtomToAF (-> Atom Bool Symbol))
-(= (addAtomToAF $atom $new)
+(: addAtomToAF (-> Atom Symbol))
+(= (addAtomToAF $atom)
    (if (== (getValueType $atom) %Undefined%)
        ("Atom is not valid")
        (let* 
@@ -56,12 +56,9 @@
                 (() (add-atom &attentionalFocus $atom))
                 (() (if (contains (getNewAtomInAVList) $atom)
                         ()
-                        (if $new
-                            (let $wrote
-                                (write_csv_wrapper (attentionalFocus))
-                                (add-atom &newAtomInAV $atom)
-                            )
-                            ()
+                        (let $wrote
+                            (write_csv_wrapper (attentionalFocus))
+                            (add-atom &newAtomInAV $atom)
                         )
                     )
                 )
@@ -217,8 +214,8 @@
 ;Parameters:
 ;          $atom: The atom to be added or updated.
 ;Returns: Nothing if no update occurs, otherwise the atom is added.
-(: updateAttentionalFocus (-> Atom Bool empty))
-(= (updateAttentionalFocus $atom $newAtom)
+(: updateAttentionalFocus (-> Atom empty))
+(= (updateAttentionalFocus $atom)
    (let*
        (
         
@@ -232,16 +229,16 @@
            ; Case 1: Atom is already in AF, update its value
            (let ()
                (remove-atom &attentionalFocus $atom)
-               (addAtomToAF $atom $newAtom)
+               (addAtomToAF $atom)
            )
            (if (< $currentSize $maxSize)
                ; Case 2: AF is not full, add the new atom
-               (addAtomToAF $atom $newAtom)
+               (addAtomToAF $atom)
                (let $lowestAtom (getLowestStiAtomInAF) ; Only compute if needed
                     (if (> $sti (getSti $lowestAtom))  ; Case 3: Replace if better
                         (let ()
                             (remove-atom &attentionalFocus $lowestAtom)
-                            (addAtomToAF $atom True)
+                            (addAtomToAF $atom)
                         )
                         () ; Case 4: Atom not added
                     )

--- a/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
+++ b/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
@@ -59,19 +59,19 @@
 ; Test case 06: Testing updateAttentionalFocus by adding new atom to attentional focus
 
 !(setAv G (300.0 400.0 500.0))
-!(assertEqual (updateAttentionalFocus G True) ("Atom Added"))
+!(assertEqual (updateAttentionalFocus G) ("Atom Added"))
 !(assertEqual (getAtomList) (a d c A B C D F (EvaluationLink a b) (Hebbianlink (Hebbianlink Cat Human) Animal) G))
 
 
 ; Test case 07: Testing updateAttentionalFocus by changing values of saved atom
 
 !(setAv G (15.0 25.0 35.0))
-!(assertEqual (updateAttentionalFocus G True) ("Atom Added"))
+!(assertEqual (updateAttentionalFocus G) ("Atom Added"))
 !(assertEqual (getAtomList) (a d c A B C D F (EvaluationLink a b) (Hebbianlink (Hebbianlink Cat Human) Animal) G))
 
 ; Test case 08: Testing updateAttentionalFocus adding an atom without AV 
 
-!(assertEqual (updateAttentionalFocus L True) ("Atom is not valid"))
+!(assertEqual (updateAttentionalFocus L) ("Atom is not valid"))
 ; !(assertEqual (getAtomList) (a A B C D F G))
 
 

--- a/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
+++ b/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
@@ -46,56 +46,41 @@
 
 !(assertEqual (atomIsInAF Z) False)
 
-
-; Test case 04: Testing sortAtomsBySti sorts atoms and returns sorted list
-
-!(assertEqual (sortAtomsBySti  (getAtomList)) (c a d D B F A (EvaluationLink a b) C (Hebbianlink (Hebbianlink Cat Human) Animal)))
-
-; Test case 05: Testing getLowestStiAtomInAF returns an atom with lowest Sti
+; Test case 04: Testing getLowestStiAtomInAF returns an atom with lowest Sti
 
 !(assertEqual (getLowestStiAtomInAF) c)
 
 
-; Test case 06: Testing updateAttentionalFocus by adding new atom to attentional focus
+; Test case 05: Testing updateAttentionalFocus by adding new atom to attentional focus
 
 !(setAv G (300.0 400.0 500.0))
 !(assertEqual (updateAttentionalFocus G) ("Atom Added"))
 !(assertEqual (getAtomList) (a d c A B C D F (EvaluationLink a b) (Hebbianlink (Hebbianlink Cat Human) Animal) G))
 
 
-; Test case 07: Testing updateAttentionalFocus by changing values of saved atom
+; Test case 06: Testing updateAttentionalFocus by changing values of saved atom
 
 !(setAv G (15.0 25.0 35.0))
 !(assertEqual (updateAttentionalFocus G) ("Atom Added"))
 !(assertEqual (getAtomList) (a d c A B C D F (EvaluationLink a b) (Hebbianlink (Hebbianlink Cat Human) Animal) G))
 
-; Test case 08: Testing updateAttentionalFocus adding an atom without AV 
+; Test case 07: Testing updateAttentionalFocus adding an atom without AV 
 
 !(assertEqual (updateAttentionalFocus L) ("Atom is not valid"))
 ; !(assertEqual (getAtomList) (a A B C D F G))
 
 
-; Test case 09; Testing sortAtomsBySti checking new order of atoms
-
 !(assertEqual (sortAtomsBySti  (getAtomList)) (c a d G D B F A (EvaluationLink a b) C (Hebbianlink (Hebbianlink Cat Human) Animal)))
 
 
-; Test case 10: Testing getRandomAtomNotInAF assure that only one atom is returned
+; Test case 09: Testing getRandomAtomNotInAF assure that only one atom is returned
 
 !(let $res (collapse (getRandomAtomNotInAF)) (assertEqual (size-atom $res) 1))
 
 
-; Test case 11: Testing getAfMaxSTI, lessthanSti and geraterequalsti to get the updated values
+; Test case 10: Testing getAfMaxSTI
 
-!(assertEqual (let $atoms (getAtomList)
-(getAllMaxSTI $atoms)) 200.0)
-!(assertEqual (lessThanSti B C) True)
-!(assertEqual (greaterEqualSti B (Hebbianlink (Hebbianlink Cat Human) Animal)) False)
-
-; Test case 12: Testing sortAtomsByStiDescending to check if it sorts atoms in descending STI
-
-!(assertEqual(sortAtomsByStiDescending  (getAtomList)) ((Hebbianlink (Hebbianlink Cat Human) Animal) C (EvaluationLink a b) A F B D G d a c))
-
+!(assertEqual (let $atoms (getAtomList) (getAllMaxSTI $atoms)) 200.0)
 
 ;################ Prep: adding to attensionalfocus space to test link match ####################
 
@@ -116,66 +101,9 @@
 ; ########################### Testing ##################################
 
 
-; Test case 13: Testing getIncomingSet function 
+; Test case 11: Testing getIncomingSet function 
 !(assertEqual (getIncomingSet abebe habbianlink) ((habbianlink abebe kebede) (habbianlink challa abebe)))
 
-
-; Test case 14: Testing nodeMatch against values in and out of attentionalFocus 
-
-!(assertEqual (nodeMatch  (PlusLink abebe kebede) (PlusLink abebe kebede)) True) 
-!(assertEqual (nodeMatch  (PlusLink abebe kebede) (PlusLink kebede abebe)) False) 
-!(assertEqual (nodeMatch (ConceptNode abebe) (ConceptNode abebe)) False)
-!(assertEqual (nodeMatch () ()) False)
-
-
-; Test case 15: Testing linkMatch
-
-!(assertEqual (linkMatch (habbianlink challa abebe) (habbianlink challa abebe)) True)
-!(assertEqual (linkMatch (CHOICE_LINK A B ) (ORLink A B )) True) ; if choice_link return True 
-!(assertEqual (linkMatch (ORLink A B ) (AndLink C D )) False) ; if first type differ return False 
-!(assertEqual (linkMatch (AndLink A B C ) (AndLink X Y  )) False)  ;arity is different
-!(assertEqual (linkMatch (AndLink A B) (AndLink J C)) False) ; Atom not in AF
-!(assertEqual (linkMatch (AndLink A B) (AndLink E F)) True) ;This works 
-!(assertEqual (linkMatch (SCOPE_LINK $x $y ) (SCOPE_LINK $z $w)) False) ;because of different variables
-!(assertEqual (linkMatch (SCOPE_LINK $x $y ) (SCOPE_LINK $x $y)) True) ;because of same variables
-
-
-; Test case 16: Testing termMatchMixinLinkMatch using various links
-
-!(assertEqual (termMatchMixinLinkMatch (a) (a)) True)
-!(assertEqual (termMatchMixinLinkMatch (z) (z)) True)
-!(assertEqual (termMatchMixinLinkMatch (a) (b)) False)
-!(assertEqual (termMatchMixinLinkMatch (CHOICE_LINK A B) (a)) True)
-!(assertEqual (termMatchMixinLinkMatch (a) (CHOICE_LINK A B)) False)
-!(assertEqual (termMatchMixinLinkMatch (a b c) (a A B)) True)
-!(assertEqual (termMatchMixinLinkMatch (SCOPE_LINK b c) (SCOPE_LINK A B)) True)
-!(assertEqual (termMatchMixinLinkMatch (SCOPE_LINK $b c) (SCOPE_LINK A $B)) False)
-!(assertEqual (termMatchMixinLinkMatch (SCOPE_LINK $b c) (SCOPE_LINK A $b)) True)
-!(assertEqual (termMatchMixinLinkMatch (SCOPE_LINK $b c) (SCOPE_LINK A $b)) True)
-
-
-; Test case 17: Testing tupleCount Function
-
-!(assertEqual (tupleCount (AndLink A B C)) 4)
-!(assertEqual (tupleCount (AndLink)) 1)
-!(assertEqual (tupleCount ()) 0)
-
-
-; Test case 18: Testing getArity Function 
-
-!(assertEqual (getArity (AndLink A B C)) 3)
-!(assertEqual (getArity (AndLink X Y)) 2)
-!(assertEqual (getArity ()) 0)
-
-
-; Test case 19: Testing getVariables with different list inputs
-
-!(assertEqual (getVariables (SCOPE_LINK $x $y ) ) ($x ($y ()))) 
-!(assertEqual (getVariables (SCOPE_LINK $z $w) )  ($z ($w ())))
-!(assertEqual (getVariables (SCOPE_LINK z w) )  ())
-!(assertEqual (getVariables ())  ())
-
-
-;Test case 20: Testing filterLinksInAF method
+; Test case 12: Testing filterLinksInAF method
 
 !(assertEqual (filterLinksInAF ((Hebbianlink (Hebbianlink Cat Human) Animal) (Hebbianlink (Hebbianlink Cat Human) Dog) (EvaluationLink a b))) ((Hebbianlink (Hebbianlink Cat Human) Animal) (emtpy) (EvaluationLink a b)))

--- a/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
+++ b/attention-bank/bank/attentional-focus/tests/attentional-focus-test.metta
@@ -54,24 +54,20 @@
 ; Test case 05: Testing updateAttentionalFocus by adding new atom to attentional focus
 
 !(setAv G (300.0 400.0 500.0))
-!(assertEqual (updateAttentionalFocus G) ("Atom Added"))
+!(assertEqual (updateAttentionalFocus G) True)
 !(assertEqual (getAtomList) (a d c A B C D F (EvaluationLink a b) (Hebbianlink (Hebbianlink Cat Human) Animal) G))
 
 
 ; Test case 06: Testing updateAttentionalFocus by changing values of saved atom
 
 !(setAv G (15.0 25.0 35.0))
-!(assertEqual (updateAttentionalFocus G) ("Atom Added"))
+!(assertEqual (updateAttentionalFocus G) True)
 !(assertEqual (getAtomList) (a d c A B C D F (EvaluationLink a b) (Hebbianlink (Hebbianlink Cat Human) Animal) G))
 
 ; Test case 07: Testing updateAttentionalFocus adding an atom without AV 
 
-!(assertEqual (updateAttentionalFocus L) ("Atom is not valid"))
+!(assertEqual (updateAttentionalFocus L) False)
 ; !(assertEqual (getAtomList) (a A B C D F G))
-
-
-!(assertEqual (sortAtomsBySti  (getAtomList)) (c a d G D B F A (EvaluationLink a b) C (Hebbianlink (Hebbianlink Cat Human) Animal)))
-
 
 ; Test case 09: Testing getRandomAtomNotInAF assure that only one atom is returned
 

--- a/attention/ForgettingAgent/ForgettingAgent.metta
+++ b/attention/ForgettingAgent/ForgettingAgent.metta
@@ -133,8 +133,8 @@
 			(
 				($head (car-atom $sortedatoms))
 				($tail (cdr-atom $sortedatoms))
-				($iset (incomingSetType $head ASYMMETRIC_HEBBIAN_LINK))
-				($niset (incomingSetUntyped $head))
+				($iset (globalIncomingSetByType $head ASYMMETRIC_HEBBIAN_LINK))
+				($niset (globalIncomingSetwithoutType $head))
 			)
 			(if (< $count $removalAmount) 
 				(if (== (size-atom $iset) (size-atom $niset))
@@ -169,39 +169,6 @@
 			False
 		)
 		False
-	)
-)
-
-: Description: a function to find incoming set from both attentioanl focus and typeSpace.
-; params:
-;		$atom: atom whose incoming set is to be searched
-;		$type: type of the link of the returned incoming set
-; return: all set of incoiming sets with matching types
-(: incomingSetType (-> Atom Atom List))
-(= (incomingSetType $atom $type)
-	(let* 
-		(
-			($selfiset (globalIncomingSetByType $atom $type))
-			($attiset (getIncomingSetByType $atom $type))
-			($union (union-atom $selfiset $attiset))
-		)
-		(unique-atom $union)
-	)
-)
-
-: Description: a function to find incoming set from both attentioanl focus and self typeSpace.
-; params:
-;		$atom: atom whose incoming set is to be searched
-; return: all set of incoiming sets not specifc of types
-(: incomingSetType (-> Atom Atom List))
-(= (incomingSetUntyped $atom)
-	(let* 
-		(
-			($selfiset (globalIncomingSetwithoutType $atom))
-			($attiset (getIncomingSetwithoutType $atom))
-			($union (union-atom $selfiset $attiset))
-		)
-		(unique-atom $union)
 	)
 )
 


### PR DESCRIPTION
This pull request is aimed at making cleanups on the attentional-focus file
1. reduces the Boolean argument from addAtomToAf function which is no longer necessary as hebbian creation does not call setAv
2. removes functions that are not called
3. reduces tests for unused functions
4. adds documentation of undocumented functions
5. changes functions that return sting to return () or Boolean