### PR TITLE
Clean up/importance index

### DIFF
--- a/attention-bank/bank/attentional-focus/attentional-focus.metta
+++ b/attention-bank/bank/attentional-focus/attentional-focus.metta
@@ -70,7 +70,7 @@
 ;Description: Retrieves a list of all atoms currently in attentional focus space.
 ;Parameters: None.
 ;Returns: A list of atoms in attentional focus space.
-(: getAtomList(-> Symbol))
+(: getAtomList (-> Expression))
 (= (getAtomList)
    (collapse (get-atoms &attentionalFocus))
 )
@@ -79,7 +79,7 @@
 ;Description: Retrieves a list of all atoms currently in the newAtomInAV space.
 ;Parameters: None.
 ;Returns: A list of atoms in newAtomInAV space.
-(: getNewAtomInAVList(-> Symbol))
+(: getNewAtomInAVList (-> Expression))
 (= (getNewAtomInAVList)
    (collapse (get-atoms &newAtomInAV))
 )

--- a/attention-bank/bank/importance-index/importance-index.metta
+++ b/attention-bank/bank/importance-index/importance-index.metta
@@ -119,19 +119,32 @@
 
 (: updateImportance (-> hyperon::space::DynSpace Atom Number Number Bool))
 (= (updateImportance $space $atom $oldSTI $newSTI)
-    (let* 
-        (
-            ($oldBin (importanceBin $oldSTI))
-            ($newBin (importanceBin $newSTI))
-           
+    (if (== (getValueType $atom) %Undefined%)
+        (let $newBin
+            (importanceBin $newSTI)
+            (insertAtom $newBin $atom)
         )
-        (let $result 
-                    (relocateAtom $oldBin $newBin $atom)
-                    $result)
+        (let* 
+            (
+                ($oldBin (importanceBin $oldSTI))
+                ($newBin (importanceBin $newSTI))
+               
+            )
+            (if (== $newBin $oldBin)
+                True
+                (relocateAtom $oldBin $newBin $atom)
+            )
+        )
     )
 )
 
 
+;; Function: relocateAtom
+;; Parameters:
+;;      $oldBin: The bin index where the atom will be removed
+;;      $newBin: The bin index where the atom will be inserted
+;;      $atom: The pattern of the to relocate
+;; Return: True if sucessfully relocated
 (: relocateAtom (-> Number Number Symbol Bool))
 (= (relocateAtom $oldBin $newBin $atom)
    (let* (($res1 (removeAtom $oldBin $atom))


### PR DESCRIPTION
This update makes minor modifications on type and optimization

1. it changes the return type for getAtomList and getNewAtomInAvList from Symbol to Expression
2. upadtes the updateimportance so 
3.1 it only calls insert atom on new atoms
3.2 it does not call relocate atom for atoms whose bin is not changed