### PR TITLE
Add optional RecentVal implementation

### DIFF
--- a/attention-bank/bank/importance-index/importance-index.metta
+++ b/attention-bank/bank/importance-index/importance-index.metta
@@ -170,6 +170,28 @@
 (: getMinSTI (-> Number))
 (= (getMinSTI) (let $recentVal (RecentVal) (match $recentVal (recent_min $_) $_)))
 
+; (: getMaxSTI (-> Bool Number))
+; (= (getMaxSTI $avg) 
+
+;     (if $avg
+;       (getAttentionParam RECENT_MAX)
+;       (getMaxSTI)
+;       )
+; )
+
+; (: getMaxSTI (-> Number))
+; (= (getMaxSTI) (getAttentionParam MAX_STI))
+
+; (: getMinSTI (-> Bool Number))
+; (= (getMinSTI $avg)
+;    (if $avg
+;       (getAttentionParam RECENT_MIN)
+;       (getMinSTI)
+;       )
+; )
+
+; (: getMinSTI (-> Number))
+; (= (getMinSTI) (getAttentionParam MIN_STI))
 
 ;Function: getNormalisedZeroToOneSTI
 ;Description: Normalizes an atom's STI based on the minimum and maximum STI values.

--- a/attention-bank/utilities/recentVal.metta
+++ b/attention-bank/utilities/recentVal.metta
@@ -48,3 +48,37 @@
       ()
     )
 )
+
+
+; optional implementation of recentval using max and min as a global variable in attentionParams instead of recentVal which avoids extra space
+; when updateValue is called, it updates the global variables
+;according to this mathematical relationship between the three:
+    ;recent = ((decay * newValue) + ((decay - 1.0) * recent))
+    ;where: newValue is the value passed as the argument to the update functions. 
+; (: updateMin (-> Number empty))
+; (= (updateMin $newValue)
+;    (let*
+;      (
+;         ($current (getAttentionParam MIN_STI))
+;         ($recent (getAttentionParam RECENT_MIN))
+;         ($decay (getAttentionParam DECAY_MIN))
+;         ($newRecent (+ (* $decay $newValue) (* $recent (- 1.0 $decay))))
+;         ($_ (updateAttentionParam MIN_STI $newValue))
+;       )
+;       (updateAttentionParam RECENT_MIN $newRecent)
+;     )
+; )
+
+; (: updateMax (-> Number empty))
+; (= (updateMax $newValue)
+;    (let*
+;      (
+;         ($current (getAttentionParam MAX_STI))
+;         ($recent (getAttentionParam RECENT_MAX))
+;         ($decay (getAttentionParam DECAY_MAX))
+;         ($newRecent (+ (* $decay $newValue) (* $recent (- 1.0 $decay))))
+;         ($_ (updateAttentionParam MAX_STI $newValue))
+;       )
+;       (updateAttentionParam RECENT_MAX $newRecent)
+;     )
+; )

--- a/attention/AttentionParam.metta
+++ b/attention/AttentionParam.metta
@@ -31,6 +31,12 @@
 !(add-atom &attentionParam  (TARGET_LTI 10000))
 !(add-atom &attentionParam  (STI_ATOM_WAGE 10))
 !(add-atom &attentionParam  (LTI_ATOM_WAGE 10))
+; !(add-atom &attentionParam  (MIN_STI 0.0)) ; used for recentVal optional implementation
+; !(add-atom &attentionParam  (RECENT_MIN 0.0))
+; !(add-atom &attentionParam  (RECENT_MAX 0.0))
+; !(add-atom &attentionParam  (MAX_STI 0.0))
+; !(add-atom &attentionParam  (DECAY_MIN 1))
+; !(add-atom &attentionParam  (DECAY_MAX 1))
 (: getAttentionParam (-> Symbol Number))
 (= (getAttentionParam $param)
    (match &attentionParam ($param $x) $x)


### PR DESCRIPTION
#### Summary

- i have added global variables MIN_STI, MAX_STI, RECENT_MIN, RECENT_MAX, DECAY_MIN, DECAY_MAX for value_min, value_max, recent_min, recent_max, deacy_min and decay_max respectively.
- implemented recentVal functions i.e updateMin and updateMax using those global variables and updateAttentionParam function
- Modified the getMin and Max sti functions in importanceIndex to use global variables 
- the code can be useful incase we want to avoid recentVal space.
### test 
- you can test by uncomment the global variables and new functions and comment the complementary previous functions 