### PR TITLE
Feat/synapse imp

### DIFF
--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -57,6 +57,30 @@
     )
 )
 
+(= (log2-math $x)
+    (if (> $x 0.0)
+        (log-math 2.0 $x)
+        0.0
+    )
+)
+
+(= (entropyTerm $p)
+     (if (> $p 0)
+       (* $p (log2-math $p))
+       0.0
+     )
+)
+
+(= (averageList $list)
+    (let* 
+        (
+            ($sum (foldl-atom $list 0.0 $acc $x (+ $acc $x)))
+            ($count (size-atom $list))
+        )
+        (if (> $count 0) (/ $sum $count) 0.0)
+    )
+)
+
 (= (afResourceUsage)
     (let $allSize
         (size-atom (getAllAtomsWithBins))
@@ -136,94 +160,53 @@
 (= (getLinkTarget (ASYMMETRIC_HEBBIAN_LINK $src $tgt)) $tgt)
 
 (= (isInternalLink $link $afAtoms)
-  (let*
-     (
-       ($tgt (getLinkTarget $link))
-       ;; wrap target in tuple to use intersection-atom against the afAtoms
-       ($overlap (size-atom (intersection-atom $afAtoms (cons $tgt ()))))
-     )
-     (if (> $overlap 0) 1 0)
-  )
-)
-
-(= (connectionRatio)
-  (let*
-      (
-        ($afAtoms (getAfAtoms))
-        ($allAfLinks (getHebLinks $afAtoms ()))
-        ($totalLinks (size-atom $allAfLinks))
-
-        ;; map over links to get the internal ones
-        ($internalFlags (map-atom $allAfLinks $link (isInternalLink $link $afAtoms)))
-        ($internalLinks (foldl-atom $internalFlags 0 $acc $x (+ $acc $x)))
-      )
+    (let*
         (
-        if (> $totalLinks 0)
-          (/ $internalLinks $totalLinks)
-          0.0
+            ($tgt (getLinkTarget $link))
+            ;; wrap target in tuple to use intersection-atom against the afAtoms
+            ($overlap (size-atom (intersection-atom $afAtoms (cons $tgt ()))))
         )
-  )
-)
-
-(= (log2-math $x)
-    (if (> $x 0.0)
-        (log-math 2.0 $x)
-        0.0
+        (if (> $overlap 0) 1 0)
     )
 )
 
-(= (entropyTerm $p)
-     (if (> $p 0)
-       (* $p (log2-math $p))
-       0.0
-     )
+(= (connectionRatio)
+    (let*
+        (
+            ($afAtoms (getAfAtoms))
+            ($allAfLinks (getHebLinks $afAtoms ()))
+            ($totalLinks (size-atom $allAfLinks))
+
+            ;; map over links to get the internal ones
+            ($internalFlags (map-atom $allAfLinks $link (isInternalLink $link $afAtoms)))
+            ($internalLinks (foldl-atom $internalFlags 0 $acc $x (+ $acc $x)))
+        )
+        (if (> $totalLinks 0)
+            (/ $internalLinks $totalLinks)
+            0.0
+        )
+    )
 )
 
-(= (preallocationSpace)
-  (let* 
-     (
-        ($allAtoms (getAllAtomsWithBins))
-        ($totalAtoms (size-atom $allAtoms))
-        ($totalSti (getTotalSti $allAtoms 0))
-        ($probabilities (map-atom $allAtoms $atom (/ (getSti $atom) $totalSti)))
-        ($entropyTerms (map-atom $probabilities $p (entropyTerm $p)))
-        ($sumTerms (foldl-atom $entropyTerms 0 $acc $x (+ $acc $x)))
-        ($entropy (* -1.0 $sumTerms))
-        ($maxEntropy (if (> $totalAtoms 1) (log2-math $totalAtoms) 0.0))
-      )
 
+(= (preallocationSpace)
+    (let* 
+        (
+            ($allAtoms (getAllAtomsWithBins))
+            ($totalAtoms (size-atom $allAtoms))
+            ($totalSti (getTotalSti $allAtoms 0))
+            ($probabilities (map-atom $allAtoms $atom (/ (getSti $atom) $totalSti)))
+            ($entropyTerms (map-atom $probabilities $p (entropyTerm $p)))
+            ($sumTerms (foldl-atom $entropyTerms 0 $acc $x (+ $acc $x)))
+            ($entropy (* -1.0 $sumTerms))
+            ($maxEntropy (if (> $totalAtoms 1) (log2-math $totalAtoms) 0.0))
+        )
         (if (> $maxEntropy 0)
             (/ $entropy $maxEntropy)
             0.0
         )
-  )
+    )
 )
-
-; ;; cognitive maintainance (recursive list version)
-; (= (cognitiveMaintainanceHelper () $sum $count)
-;      (if (> $count 0) (/ $sum $count) 0.0)
-; )
-;
-; (= (cognitiveMaintainanceHelper (cons $single ()) $sum $count)
-;      (if (> $count 0) (/ $sum $count) 0.0)
-; )
-;
-; (= (cognitiveMaintainanceHelper (cons $state1 (cons $state2 $tail)) $sum $count)
-;      (let*
-;           (
-;              ($retention (contextRetention $state1 $state2))
-;              ($newSum (+ $sum $retention))
-;              ($newCount (+ $count 1))
-;           )
-;      )
-;      (
-;        (cognitiveMaintainanceHelper (cons $state2 $tail) $newSum $newCount)
-;      )
-; )
-;
-; (= (cognitiveMaintainance $trajectory)
-;      (cognitiveMaintainanceHelper $trajectory 0.0 0)
-; )
 
 (= (cognitiveMaintenance $oldState $newState $oldMean $oldCount)
     (let*
@@ -232,163 +215,10 @@
             ($newCount (+ $oldCount 1.0))
             ($weightOld (* $oldMean (/ $oldCount $newCount)))
             ($weightNew (/ $retention $newCount))
-            
             ($newMean (+ $weightOld $weightNew))
         )
         $newMean
     )
 )
 
-(= (averageList $list)
-    (let* 
-         (
-            ($sum (foldl-atom $list 0.0 $acc $x (+ $acc $x)))
-            ($count (size-atom $list))
-         )
-         (if (> $count 0) (/ $sum $count) 0.0)
-    )
-)
 
-;; internal coherence for a single module
-(= (moduleInternalCoherence $moduleAtoms)
-    (let*
-        (
-          ($moduleSize (size-atom $moduleAtoms))
-          ($allLinks (getHebLinks $moduleAtoms ()))
-          ($internalFlags (map-atom $allLinks $link (isInternalLink $link $moduleAtoms)))
-          ($internalCount (foldl-atom $internalFlags 0 $acc $x (+ $acc $x)))
-
-          ($maxLinks (* $moduleSize (- $moduleSize 1)))
-        )
-        (if (> $maxLinks 0) (/ $internalCount $maxLinks) 0.0)
-     )
-)
-
-(= (globalCoordination $state)
-    (let*
-         (
-            ($modules (identifyModules $state)) ;; todo -> write a module identifier
-
-            ($localCoherences (map-atom $modules $mod (moduleInternalCoherence $mod)))
-            ($localCoherence (averageList $localCoherences))
-            ($allAtoms (getAllAtomsWithBins))
-            ($totalLinks (size-atom (getHebLinks $allAtoms ())))
-            
-            ($internalCounts (map-atom $modules $mod 
-                (foldl-atom (map-atom (getHebLinks $mod ()) $link (isInternalLink $link $mod)) 0 $acc $x (+ $acc $x))
-            ))
-            ($totalInternal (foldl-atom $internalCounts 0 $acc $x (+ $acc $x)))
-
-            ($totalExternal (- $totalLinks $totalInternal))
-            ($globalCoherence (if (> $totalLinks 0) (/ $totalExternal $totalLinks) 0.0))
-
-            ($coordination (sqrt-math (* $localCoherence $globalCoherence)))
-         )
-        $coordination
-    )
-)
-
-(= (systemPerformance $state)
-  ;; todo -> an actual performance metrics is required
-  1.0
-)
-
-(= (totalResourceCost $state)
-  ;; todo -> again an actual cost metrics is required, I will try out afResourceUsage
-  1.0
-)
-
-(= (gainedEfficiency $optimizedState $baselineState)
-    (let*
-        (
-           ($baselineCost (totalResourceCost $baselineState))
-           ($optimizedCost (totalResourceCost $optimizedState))
-           ($baselinePerf (systemPerformance $baselineState))
-           ($optimizedPerf (systemPerformance $optimizedState))
-
-           ($baselineEff
-              (if (> $baselineCost 0) (/ $baselinePerf $baselineCost) 0.0)
-           )
-           ($optimizedEff 
-                (if (> $optimizedCost 0) (/ $optimizedPerf $optimizedCost) 0.0)
-           )
-
-           ($efficiencyDiff (- $optimizedEff $baselineEff))
-        ) 
-
-        (if (> $baselineEff 0)
-            (/ $efficiencyDiff $baselineEff)
-            0.0
-        )
-    )
-)
-
-
-
-(= (getClipIndex (CIPSnapshot $index $state $time $metrics)) $index)
-
-(= (cipCurrentTime)
- ;; bind to an actual time lib
- 0 
-)
-
-(= (measureAllMetrics $state $trajectory)
-   ((DummyMetric 1.0))
-)
-
-(= (initializeBaselineClip $initialState)
-    (let*
-        (
-            ($metrics (measureAllMetrics $initialState ()))
-            ($timestamp (cipCurrentTime))
-        )
-        (CIPSnapshot 0 $initialState $timestamp $metrics)
-    )
-)
-
-(= (transitionToNextClip $prevClip $newState $trajectory)
-    (let*
-        (
-          ($prevIndex (getClipIndex $prevClip))
-          ($newIndex (+ $prevIndex 1))
-
-          ($metrics (measureAllMetrics $newState $trajectory))
-
-          ($timestamp (cipCurrentTime))
-    )
-     (CIPSnapshot $newIndex $newState $timestamp $metrics)
-    )
-)
-
-;; todo -> implement the ones below
-(= (countTriangles $links)
-    0
-)
-
-(= (calculateBetti0 $links)
-    1
-)
-
-(= (calculateBetti1 $links)
-    0
-)
-
-(= (calculateBetti2 $links)
-    0
-)
-
-(= (presistentHomologyInvariants $state)
-    (let*
-        ( 
-          ($allAtoms (getAllAtomsWithBins))
-          ($hlinks (getHebLinks $allAtoms ()))
-            
-          ($triangles (countTriangles $hlinks))
-          ($betti0 (calculateBetti0 $hlinks))
-          ($betti1 (calculateBetti1 $hlinks))
-          ($betti2 (calculateBetti2 $hlinks))
-        )        
-        (TopologyReport $triangles $betti0 $betti1 $betti2)
-      
-    )
-)

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -154,7 +154,7 @@
         ($totalLinks (size-atom $allAfLinks))
 
         ;; map over links to get the internal ones
-        ($internalFlags (map-atom $allAfLinks $link (isInternalLink $link $afAtoms))
+        ($internalFlags (map-atom $allAfLinks $link (isInternalLink $link $afAtoms)))
         ($internalLinks (foldl-atom $internalFlags 0 $acc $x (+ $acc $x)))
       )
         (
@@ -178,10 +178,10 @@
         ($allAtoms (getAllAtomsWithBins))
         ($totalAtoms (size-atom $allAtoms))
         ($totalSti (getTotalSti $allAtoms 0))
-        ($probabilities (map-atom $allAtoms $atom)(/ (getsti $atom) $totalSti))
-        ($entropyTerms (map-atom $probabiliries $p (entropyTerm $p)))
+        ($probabilities (map-atom $allAtoms $atom (/ (getSti $atom) $totalSti)))
+        ($entropyTerms (map-atom $probabilities $p (entropyTerm $p)))
         ($sumTerms (foldl-atom $entropyTerms 0 $acc $x (+ $acc $x)))
-        ($entropy (* -1 $sumTerms))
+        ($entropy (* -1.0 $sumTerms))
         ($maxEntropy (log2-math $totalAtoms))
       )
 
@@ -204,13 +204,13 @@
 (= (cognitiveMaintainanceHelper (cons $state1 (cons $state2 $tail)) $sum $count)
      (let*
           (
-             ($retenttion (contextRetention $state1 $state2))
+             ($retention (contextRetention $state1 $state2))
              ($newSum (+ $sum $retention))
              ($newCount (+ $count 1))
           )
      )
      (
-       (cognitiveMaintainanceHelper (cons state2 $tail) $newSum $newCount)
+       (cognitiveMaintainanceHelper (cons $state2 $tail) $newSum $newCount)
      )
 )
 (= (cognitiveMaintainance $trajectory)
@@ -236,7 +236,7 @@
           ($internalFlags (map-atom $allLinks $link (isInternalLink $link $moduleAtoms)))
           ($internalCount (foldl-atom $internalFlags 0 $acc $x (+ $acc $x)))
 
-          ($maxLinks (* $moduleSize (- $moduleSize)))
+          ($maxLinks (* $moduleSize (- $moduleSize 1)))
         )
         (if (> $maxLinks 0) (/ $internalCount $maxLinks) 0.0)
      )
@@ -255,12 +255,12 @@
             ($internalCounts (map-atom $modules $mod 
                 (foldl-atom (map-atom (getHebLinks $mod ()) $link (isInternalLink $link $mod)) 0 $acc $x (+ $acc $x))
             ))
-            ($totalInternal (foldl-atom $internalCounts 0 $acc $x (+ $acc $x))
+            ($totalInternal (foldl-atom $internalCounts 0 $acc $x (+ $acc $x)))
 
             ($totalExternal (- $totalLinks $totalInternal))
-            ($globalCoherence(if (> $totalLinks 0) (/ $totalExternal $totalLinks) 0.0)
+            ($globalCoherence (if (> $totalLinks 0) (/ $totalExternal $totalLinks) 0.0))
 
-            ($coordination (sqrt-math (* *localCOherence *globalCoherence)))
+            ($coordination (sqrt-math (* $localCoherence $globalCoherence)))
          )
         $coordination
     )
@@ -317,10 +317,10 @@
 (= (initializeBaselineClip $initialState)
     (let*
         (
-            ($metrics (measureAllMetrics $initialState))
+            ($metrics (measureAllMetrics $initialState ()))
             ($timestamp (currentTime))
         )
-        (CIPSnapshot 0 initialState $timestamp $metrics)
+        (CIPSnapshot 0 $initialState $timestamp $metrics)
     )
 )
 
@@ -338,7 +338,8 @@
     )
 )
 
-= (countTriangles $links)
+;; todo -> implement the ones below
+(= (countTriangles $links)
     0
 )
 

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -327,7 +327,7 @@
 
 (= (getClipIndex (CIPSnapshot $index $state $time $metrics)) $index)
 
-(= (currentTime)
+(= (cipCurrentTime)
  ;; bind to an actual time lib
  0 
 )
@@ -340,7 +340,7 @@
     (let*
         (
             ($metrics (measureAllMetrics $initialState ()))
-            ($timestamp (currentTime))
+            ($timestamp (cipCurrentTime))
         )
         (CIPSnapshot 0 $initialState $timestamp $metrics)
     )
@@ -354,7 +354,7 @@
 
           ($metrics (measureAllMetrics $newState $trajectory))
 
-          ($timestamp (currentTime))
+          ($timestamp (cipCurrentTime))
     )
      (CIPSnapshot $newIndex $newState $timestamp $metrics)
     )

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -265,3 +265,76 @@
         $coordination
     )
 )
+
+(= (systemPerformance $state)
+  ;; todo -> an actual performance metrics is required
+  1.0
+)
+
+(= (totalResourceCost $state)
+  ;; todo -> again an actual cost metrics is required, I will try out afResourceUsage
+  1.0
+)
+
+(= (gainedEfficiency $optimizedState $baselineState)
+    (let*
+        (
+           ($baselineCost (totalResourceCost $baselineState))
+           ($optimizedCost (totalResourceCost $optimizedState))
+           ($baselinePerf (systemPerformance $baselineState))
+           ($optimizedPerf (systemPerformance $optimizedState))
+
+           ($baselineEff
+              (if (> $baselineCost 0) (/ $baselinePerf $baselineCost) 0.0)
+           )
+           ($optimizedEff 
+                (if (> $optimizedCost 0) (/ $optimizedPerf $optimizedCost) 0.0)
+           )
+
+           ($efficiencyDiff (- $optimizedEff $baselineEff))
+        ) 
+
+        (if (> $baselineEff 0)
+            (/ $efficiencyDiff $baselineEff)
+            0.0
+        )
+    )
+)
+
+
+
+(= (getClipIndex (CIPSnapshot $index $state $time $metrics)) $index)
+
+(= (currentTime)
+ ;; bind to an actual time lib
+ 0 
+)
+
+(= (measureAllMetrics $state $trajectory)
+   ((DummyMetric 1.0))
+)
+
+(= (initializeBaselineClip $initialState)
+    (let*
+        (
+            ($metrics (measureAllMetrics $initialState))
+            ($timestamp (currentTime))
+        )
+        (CIPSnapshot 0 initialState $timestamp $metrics)
+    )
+)
+
+(= (transitionToNextClip $prevClip $newState $trajectory)
+    (let*
+        (
+          ($prevIndex (getClipIndex $prevClip))
+          ($newIndex (+ $prevIndex 1))
+
+          ($metrics (measureAllMetrics $newState $trajectory))
+
+          ($timestamp (currentTime))
+    )
+     (CIPSnapshot $newIndex $newState $timestamp $metrics)
+    )
+)
+

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -338,3 +338,34 @@
     )
 )
 
+= (countTriangles $links)
+    0
+)
+
+(= (calculateBetti0 $links)
+    1
+)
+
+(= (calculateBetti1 $links)
+    0
+)
+
+(= (calculateBetti2 $links)
+    0
+)
+
+(= (presistentHomologyInvariants $state)
+    (let*
+        ( 
+          ($allAtoms (getAllAtomsWithBins))
+          ($hlinks (getHebLinks $allAtoms ()))
+            
+          ($triangles (countTriangles $hlinks))
+          ($betti0 (calculateBetti0 $hlinks))
+          ($betti1 (calculateBetti1 $hlinks))
+          ($betti2 (calculateBetti2 $hlinks))
+        )        
+        (TopologyReport $triangles $betti0 $betti1 $betti2)
+      
+    )
+)

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -32,18 +32,26 @@
             ($ltiDistance (foldl-atom (map-atom $afAtoms $x (pow-math (- (getLti $x) $meanLti) 2)) 0 $acc $x (+ $acc $x)))
             ($denomenator (sqrt-math (* $stiDistance $ltiDistance)))
         ) 
-        (/ $numenator $denomenator)
+        (if (> $denomenator 0)
+            (/ $numenator $denomenator)
+            0.0
+        )
     )
 )
 
 (= (variance $stiValue) 
     (let*
         (
-            ($mean (/ (foldl-atom $stiValue 0 $acc $x (+ $acc $x)) (size-atom $stiValue)))
+            ($size (size-atom $stiValue))
+            ($sum (foldl-atom $stiValue 0 $acc $x (+ $acc $x)))
+            ($mean (if (> $size 0) (/ $sum $size) 0.0))
             ($meanDiff (map-atom $stiValue $x (pow-math (- $x $mean) 2)))
             ($numenator (foldl-atom $meanDiff 0 $acc $x (+ $acc $x)))
         )
-        (/ $numenator (size-atom $stiValue))
+        (if (> $size 0)
+            (/ $numenator $size)
+            0.0
+        )
     )
 )
 
@@ -103,10 +111,15 @@
             ($ltival (map-atom $afAtoms getLti))
             ($totalSti (foldl-atom $stival 0 $acc $x (+ $acc $x)))
             ($totalLti (foldl-atom $ltival 0 $acc $x (+ $acc $x)))
-            ($meanSti (/ $totalSti (size-atom $stival)))
-            ($meanLti (/ $totalLti (size-atom $ltival)))
+            ($sizeSti (size-atom $stival))
+            ($sizeLti (size-atom $ltival))
+            ($meanSti (if (> $sizeSti 0) (/ $totalSti $sizeSti) 0.0))
+            ($meanLti (if (> $sizeLti 0) (/ $totalLti $sizeLti) 0.0))
         )
-        (pearsonCorrelation $afAtoms $meanSti $meanLti)
+        (if (and (> $sizeSti 0) (> $sizeLti 0))
+            (pearsonCorrelation $afAtoms $meanSti $meanLti)
+            0.0
+        )
     )
 )
 
@@ -116,7 +129,10 @@
             ($overlap (size-atom (intersection-atom $state $prevState)))
             ($unionSize (+ (size-atom $prevState) (- (size-atom $state) $overlap)))
         )
-        (/ $overlap $unionSize)
+        (if (> $unionSize 0)
+            (/ $overlap $unionSize)
+            0.0
+        )
     )
 )
 
@@ -129,7 +145,10 @@
             ($maxVariance (variance-uniform $stiValue))
             ($1 (println! (sti $maxVariance $variance )))
         )
-        (/ $variance $maxVariance)
+        (if (> $maxVariance 0)
+            (/ $variance $maxVariance)
+            0.0
+        )
     )
 )
 
@@ -185,7 +204,10 @@
         ($allAtoms (getAllAtomsWithBins))
         ($totalAtoms (size-atom $allAtoms))
         ($totalSti (getTotalSti $allAtoms 0))
-        ($probabilities (map-atom $allAtoms $atom (/ (getSti $atom) $totalSti)))
+        ($probabilities (if (> $totalSti 0)
+            (map-atom $allAtoms $atom (/ (getSti $atom) $totalSti))
+            ()
+        ))
         ($entropyTerms (map-atom $probabilities $p (entropyTerm $p)))
         ($sumTerms (foldl-atom $entropyTerms 0 $acc $x (+ $acc $x)))
         ($entropy (* -1.0 $sumTerms))
@@ -328,7 +350,7 @@
 (= (getClipIndex (CIPSnapshot $index $state $time $metrics)) $index)
 
 (= (cipCurrentTime)
-  (current-time)
+ (current-time)
 )
 
 (= (measureAllMetrics $state $trajectory)

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -132,3 +132,136 @@
         (/ $variance $maxVariance)
     )
 )
+
+(= (getLinkTarget (ASYMMETRIC_HEBBIAN_LINK $src $tgt)) $tgt)
+
+(= (isInternalLink $link $afAtoms)
+  (let*
+     (
+       ($tgt (getLinkTarget $link))
+       ;; wrap target in tuple to use intersection-atom against the afAtoms
+       ($overlap (size-atom (intersection-atom $afAtoms (cons $tgt ()))))
+     )
+     (if (> $overlap 0) 1 0)
+  )
+)
+
+(= (connectionRatio)
+  (let*
+      (
+        ($afAtoms (getAfAtoms))
+        ($allAfLinks (getHebLinks $afAtoms ()))
+        ($totalLinks (size-atom $allAfLinks))
+
+        ;; map over links to get the internal ones
+        ($internalFlags (map-atom $allAfLinks $link (isInternalLink $link $afAtoms))
+        ($internalLinks (foldl-atom $internalFlags 0 $acc $x (+ $acc $x)))
+      )
+        (
+        if (> $totalLinks 0)
+          (/ $internalLinks $totalLinks)
+          0.0
+        )
+  )
+)
+
+(= (entropyTerm $p)
+     (if (> $p 0)
+       (* $p (log2-math $p))
+       0.0
+     )
+)
+
+(= (preallocationSpace)
+  (let* 
+     (
+        ($allAtoms (getAllAtomsWithBins))
+        ($totalAtoms (size-atom $allAtoms))
+        ($totalSti (getTotalSti $allAtoms 0))
+        ($probabilities (map-atom $allAtoms $atom)(/ (getsti $atom) $totalSti))
+        ($entropyTerms (map-atom $probabiliries $p (entropyTerm $p)))
+        ($sumTerms (foldl-atom $entropyTerms 0 $acc $x (+ $acc $x)))
+        ($entropy (* -1 $sumTerms))
+        ($maxEntropy (log2-math $totalAtoms))
+      )
+
+        (if (> $maxEntropy 0)
+            (/ $entropy $maxEntropy)
+            0.0
+        )
+  )
+)
+
+;; cognitive maintainance
+(= (cognitiveMaintainanceHelper () $sum $count)
+     (if (> $count 0) (/ $sum $count) 0.0)
+)
+
+(= (cognitiveMaintainanceHelper (cons $single ()) $sum $count)
+     (if (> $count 0) (/ $sum $count) 0.0)
+)
+
+(= (cognitiveMaintainanceHelper (cons $state1 (cons $state2 $tail)) $sum $count)
+     (let*
+          (
+             ($retenttion (contextRetention $state1 $state2))
+             ($newSum (+ $sum $retention))
+             ($newCount (+ $count 1))
+          )
+     )
+     (
+       (cognitiveMaintainanceHelper (cons state2 $tail) $newSum $newCount)
+     )
+)
+(= (cognitiveMaintainance $trajectory)
+     (cognitiveMaintainanceHelper $trajectory 0.0 0)
+)
+
+(= (averageList $list)
+    (let* 
+         (
+            ($sum (foldl-atom $list 0.0 $acc $x (+ $acc $x)))
+            ($count (size-atom $list))
+         )
+         (if (> $count 0) (/ $sum $count) 0.0)
+    )
+)
+
+;; internal coherence for a single module
+(= (moduleInternalCoherence $moduleAtoms)
+    (let*
+        (
+          ($moduleSize (size-atom $moduleAtoms))
+          ($allLinks (getHebLinks $moduleAtoms ()))
+          ($internalFlags (map-atom $allLinks $link (isInternalLink $link $moduleAtoms)))
+          ($internalCount (foldl-atom $internalFlags 0 $acc $x (+ $acc $x)))
+
+          ($maxLinks (* $moduleSize (- $moduleSize)))
+        )
+        (if (> $maxLinks 0) (/ $internalCount $maxLinks) 0.0)
+     )
+)
+
+(= (globalCoordination $state)
+    (let*
+         (
+            ($modules (identifyModules $state)) ;; todo -> write a module identifier
+
+            ($localCoherences (map-atom $modules $mod (moduleInternalCoherence $mod)))
+            ($localCoherence (averageList $localCoherences))
+            ($allAtoms (getAllAtomsWithBins))
+            ($totalLinks (size-atom (getHebLinks $allAtoms ())))
+            
+            ($internalCounts (map-atom $modules $mod 
+                (foldl-atom (map-atom (getHebLinks $mod ()) $link (isInternalLink $link $mod)) 0 $acc $x (+ $acc $x))
+            ))
+            ($totalInternal (foldl-atom $internalCounts 0 $acc $x (+ $acc $x))
+
+            ($totalExternal (- $totalLinks $totalInternal))
+            ($globalCoherence(if (> $totalLinks 0) (/ $totalExternal $totalLinks) 0.0)
+
+            ($coordination (sqrt-math (* *localCOherence *globalCoherence)))
+         )
+        $coordination
+    )
+)

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -31,7 +31,7 @@
             ($stiDistance (foldl-atom (map-atom $afAtoms $x (pow-math (- (getSti $x) $meanSti) 2)) 0 $acc $x (+ $acc $x)))
             ($ltiDistance (foldl-atom (map-atom $afAtoms $x (pow-math (- (getLti $x) $meanLti) 2)) 0 $acc $x (+ $acc $x)))
             ($denomenator (sqrt-math (* $stiDistance $ltiDistance)))
-        )
+        ) 
         (/ $numenator $denomenator)
     )
 )
@@ -98,7 +98,7 @@
 (= (correlation)
     (let*
         (
-            ($afAtoms (getAfAtoms))
+            ($afAtoms (getAllAtomsWithBins))
             ($stival (map-atom $afAtoms getSti))
             ($ltival (map-atom $afAtoms getLti))
             ($totalSti (foldl-atom $stival 0 $acc $x (+ $acc $x)))
@@ -123,7 +123,7 @@
 (= (selectionModulation)
     (let* 
         (
-            ($afAtoms (getAfAtoms))
+            ($afAtoms (getAllAtomsWithBins))
             ($stiValue (map-atom $afAtoms getSti))
             ($variance (variance $stiValue))
             ($maxVariance (variance-uniform $stiValue))
@@ -165,6 +165,13 @@
   )
 )
 
+(= (log2-math $x)
+    (if (> $x 0.0)
+        (log-math 2.0 $x)
+        0.0
+    )
+)
+
 (= (entropyTerm $p)
      (if (> $p 0)
        (* $p (log2-math $p))
@@ -182,7 +189,7 @@
         ($entropyTerms (map-atom $probabilities $p (entropyTerm $p)))
         ($sumTerms (foldl-atom $entropyTerms 0 $acc $x (+ $acc $x)))
         ($entropy (* -1.0 $sumTerms))
-        ($maxEntropy (log2-math $totalAtoms))
+        ($maxEntropy (if (> $totalAtoms 1) (log2-math $totalAtoms) 0.0))
       )
 
         (if (> $maxEntropy 0)

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -199,29 +199,44 @@
   )
 )
 
-;; cognitive maintainance
-(= (cognitiveMaintainanceHelper () $sum $count)
-     (if (> $count 0) (/ $sum $count) 0.0)
-)
+; ;; cognitive maintainance (recursive list version)
+; (= (cognitiveMaintainanceHelper () $sum $count)
+;      (if (> $count 0) (/ $sum $count) 0.0)
+; )
+;
+; (= (cognitiveMaintainanceHelper (cons $single ()) $sum $count)
+;      (if (> $count 0) (/ $sum $count) 0.0)
+; )
+;
+; (= (cognitiveMaintainanceHelper (cons $state1 (cons $state2 $tail)) $sum $count)
+;      (let*
+;           (
+;              ($retention (contextRetention $state1 $state2))
+;              ($newSum (+ $sum $retention))
+;              ($newCount (+ $count 1))
+;           )
+;      )
+;      (
+;        (cognitiveMaintainanceHelper (cons $state2 $tail) $newSum $newCount)
+;      )
+; )
+;
+; (= (cognitiveMaintainance $trajectory)
+;      (cognitiveMaintainanceHelper $trajectory 0.0 0)
+; )
 
-(= (cognitiveMaintainanceHelper (cons $single ()) $sum $count)
-     (if (> $count 0) (/ $sum $count) 0.0)
-)
-
-(= (cognitiveMaintainanceHelper (cons $state1 (cons $state2 $tail)) $sum $count)
-     (let*
-          (
-             ($retention (contextRetention $state1 $state2))
-             ($newSum (+ $sum $retention))
-             ($newCount (+ $count 1))
-          )
-     )
-     (
-       (cognitiveMaintainanceHelper (cons $state2 $tail) $newSum $newCount)
-     )
-)
-(= (cognitiveMaintainance $trajectory)
-     (cognitiveMaintainanceHelper $trajectory 0.0 0)
+(= (cognitiveMaintenance $oldState $newState $oldMean $oldCount)
+    (let*
+        (
+            ($retention (contextRetention $oldState $newState))
+            ($newCount (+ $oldCount 1.0))
+            ($weightOld (* $oldMean (/ $oldCount $newCount)))
+            ($weightNew (/ $retention $newCount))
+            
+            ($newMean (+ $weightOld $weightNew))
+        )
+        $newMean
+    )
 )
 
 (= (averageList $list)

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -328,8 +328,7 @@
 (= (getClipIndex (CIPSnapshot $index $state $time $metrics)) $index)
 
 (= (cipCurrentTime)
- ;; bind to an actual time lib
- 0 
+  (current-time)
 )
 
 (= (measureAllMetrics $state $trajectory)

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -132,5 +132,3 @@
         (/ $variance $maxVariance)
     )
 )
-
-(= (unrelatedhistorytest $x) 1)

--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -132,3 +132,5 @@
         (/ $variance $maxVariance)
     )
 )
+
+(= (unrelatedhistorytest $x) 1)

--- a/attention-bank/synapse/tentativeratio.metta
+++ b/attention-bank/synapse/tentativeratio.metta
@@ -1,0 +1,132 @@
+; ;; cognitive maintainance (recursive list version)
+; (= (cognitiveMaintainanceHelper () $sum $count)
+;      (if (> $count 0) (/ $sum $count) 0.0)
+; )
+;
+; (= (cognitiveMaintainanceHelper (cons $single ()) $sum $count)
+;      (if (> $count 0) (/ $sum $count) 0.0)
+; )
+;
+; (= (cognitiveMaintainanceHelper (cons $state1 (cons $state2 $tail)) $sum $count)
+;      (let*
+;           (
+;              ($retention (contextRetention $state1 $state2))
+;              ($newSum (+ $sum $retention))
+;              ($newCount (+ $count 1))
+;           )
+;      )
+;      (
+;        (cognitiveMaintainanceHelper (cons $state2 $tail) $newSum $newCount)
+;      )
+; )
+;
+; (= (cognitiveMaintainance $trajectory)
+;      (cognitiveMaintainanceHelper $trajectory 0.0 0)
+; )
+
+;; internal coherence for a single module
+(= (moduleInternalCoherence $moduleAtoms)
+    (let*
+        (
+          ($moduleSize (size-atom $moduleAtoms))
+          ($allLinks (getHebLinks $moduleAtoms ()))
+          ($internalFlags (map-atom $allLinks $link (isInternalLink $link $moduleAtoms)))
+          ($internalCount (foldl-atom $internalFlags 0 $acc $x (+ $acc $x)))
+
+          ($maxLinks (* $moduleSize (- $moduleSize 1)))
+        )
+        (if (> $maxLinks 0) (/ $internalCount $maxLinks) 0.0)
+    )
+)
+
+(= (globalCoordination $state)
+    (let*
+        (
+            ($modules (identifyModules $state)) ;; todo -> write a module identifier
+
+            ($localCoherences (map-atom $modules $mod (moduleInternalCoherence $mod)))
+            ($localCoherence (averageList $localCoherences))
+            ($allAtoms (getAllAtomsWithBins))
+            ($totalLinks (size-atom (getHebLinks $allAtoms ())))
+            
+            ($internalCounts (map-atom $modules $mod 
+                (foldl-atom (map-atom (getHebLinks $mod ()) $link (isInternalLink $link $mod)) 0 $acc $x (+ $acc $x))
+            ))
+            ($totalInternal (foldl-atom $internalCounts 0 $acc $x (+ $acc $x)))
+
+            ($totalExternal (- $totalLinks $totalInternal))
+            ($globalCoherence (if (> $totalLinks 0) (/ $totalExternal $totalLinks) 0.0))
+
+            ($coordination (sqrt-math (* $localCoherence $globalCoherence)))
+        )
+        $coordination
+    )
+)
+
+(= (systemPerformance $state)
+  ;; todo -> an actual performance metrics is required
+  1.0
+)
+
+(= (totalResourceCost $state)
+  ;; todo -> again an actual cost metrics is required, I will try out afResourceUsage
+  1.0
+)
+
+(= (gainedEfficiency $optimizedState $baselineState)
+    (let*
+        (
+           ($baselineCost (totalResourceCost $baselineState))
+           ($optimizedCost (totalResourceCost $optimizedState))
+           ($baselinePerf (systemPerformance $baselineState))
+           ($optimizedPerf (systemPerformance $optimizedState))
+           ($baselineEff
+              (if (> $baselineCost 0) (/ $baselinePerf $baselineCost) 0.0)
+           )
+           ($optimizedEff 
+                (if (> $optimizedCost 0) (/ $optimizedPerf $optimizedCost) 0.0)
+           )
+           ($efficiencyDiff (- $optimizedEff $baselineEff))
+        ) 
+        (if (> $baselineEff 0)
+            (/ $efficiencyDiff $baselineEff)
+            0.0
+        )
+    )
+)
+
+
+(= (getClipIndex (CIPSnapshot $index $state $time $metrics)) $index)
+
+(= (cipCurrentTime)
+ ;; bind to an actual time lib
+ 0 
+)
+
+(= (measureAllMetrics $state $trajectory)
+   ((DummyMetric 1.0))
+)
+
+(= (initializeBaselineClip $initialState)
+    (let*
+        (
+            ($metrics (measureAllMetrics $initialState ()))
+            ($timestamp (cipCurrentTime))
+        )
+        (CIPSnapshot 0 $initialState $timestamp $metrics)
+    )
+)
+
+(= (transitionToNextClip $prevClip $newState $trajectory)
+    (let*
+        (
+            ($prevIndex (getClipIndex $prevClip))
+            ($newIndex (+ $prevIndex 1))
+
+            ($metrics (measureAllMetrics $newState $trajectory))
+
+            ($timestamp (cipCurrentTime))
+        )
+        (CIPSnapshot $newIndex $newState $timestamp $metrics)
+    )
+)

--- a/experiments/experiment.metta
+++ b/experiments/experiment.metta
@@ -9,6 +9,7 @@
 
 !(import! &self ../attention/AttentionParam)
 !(import! &self ../attention/baching)
+
 !(import! &self ../attention-bank/utilities/helper-functions)
 !(import! &self ../attention-bank/utilities/recentVal)
 !(import! &self "../attention/ImportanceDiffusionAgent/getelement.py")
@@ -111,7 +112,7 @@
                     )
                     (
                         (println! (agent not called))
-                        (write_metrics_wrapper $counter (afResourceUsage) (stiConcentration) (linkDensity) (connectionRatio) (preallocationSpace) 0.0 (correlation) (selectionModulation))
+                        (write_metrics_wrapper $counter (afResourceUsage) (stiConcentration) (linkDensity) (connectionRatio) (preallocationSpace) "NaN" (correlation) (selectionModulation))
                     )
                 )
                 ; (py-call (time.sleep 5.0))

--- a/experiments/experiment.metta
+++ b/experiments/experiment.metta
@@ -1,7 +1,6 @@
 !(bind! &insect (new-space))
 ; !(bind! &poison (new-space))
 !(import! &insect data/insect-sent)
-
 !(import! &self lib/lib_import)
 !(import! &self lib/lib_spaces)
 !(import! &self lib/lib_he)
@@ -83,12 +82,29 @@
                             (getAfAtoms)
                             (add-atom &afsnap (currState $nextaf))
                         )
-                        (println! (retention (contextRetention 
-                            (car-atom (collapse (match (afSnap) (prevState $x) $x)))
-                            (car-atom (collapse (match (afSnap) (currState $x) $x)))
-                            )))
+                        (let* 
+                            (
+                                ($prevState (car-atom (collapse (match (afSnap) (prevState $x) $x))))
+                                ($currState (car-atom (collapse (match (afSnap) (currState $x) $x))))
+                                ($retentionValue (contextRetention $prevState $currState))
+                                ($afResource (afResourceUsage))
+                                ($stiConc (stiConcentration))
+                                ($linkDen (linkDensity))
+                                ($connRatio (connectionRatio))
+                                ($stiEntropy (preallocationSpace))
+                                ($pcorr (correlation))
+                                ($modulation (selectionModulation))
+                            )
+                            (
+                                (println! (retention $retentionValue))
+                                (write_metrics_wrapper $counter $now true $afResource $stiConc $linkDen $connRatio $stiEntropy $retentionValue $pcorr $modulation)
+                            )
+                        )
                     )
-                    (println! (agent not called))
+                    (
+                        (println! (agent not called))
+                        (write_metrics_wrapper $counter $now false (afResourceUsage) (stiConcentration) (linkDensity) (connectionRatio) (preallocationSpace) 0.0 (correlation) (selectionModulation))
+                    )
                 )
                 ; (py-call (time.sleep 5.0))
                 (insectPoisonReadExp $rest (+ $counter 1)))

--- a/experiments/experiment.metta
+++ b/experiments/experiment.metta
@@ -60,6 +60,30 @@
 !(start-log (attentionParam) "experiments")
 
 (= (batch) 20)
+
+(= (logCurrStateMetrics $counter)
+    (
+        (let*
+            (
+                ($prevState (car-atom (collapse (match (afSnap) (prevState $x) $x))))
+                ($currState (car-atom (collapse (match (afSnap) (currState $x) $x))))
+                ($retentionValue (contextRetention $prevState $currState))
+                ($afResource (afResourceUsage))
+                ($stiConc (stiConcentration))
+                ($linkDen (linkDensity))
+                ($connRatio (connectionRatio))
+                ($stiEntropy (preallocationSpace))
+                ($pcorr (correlation))
+                ($modulation (selectionModulation))
+            )
+            (
+                (println! (retention $retentionValue))
+                (write_metrics_wrapper $counter $afResource $stiConc $linkDen $connRatio $stiEntropy $retentionValue $pcorr $modulation)
+            )
+        )
+    )
+)
+
 (= (insectPoisonReadExp $expr $counter)
     (if (== $expr ())
         (empty)
@@ -77,33 +101,17 @@
                         (collapse (match (afSnap) (prevState $val) (remove-atom &afsnap (prevState $val))))
                         (add-atom &afsnap (prevState $af))
                         (collapse (test-superpose &incident))
+                        ; (unify $incident ($now $links) (found $now) (notfound $now))
                         (collapse (match (afSnap) (currState $val) (remove-atom &afsnap (currState $val))))
                         (let $nextaf
                             (getAfAtoms)
                             (add-atom &afsnap (currState $nextaf))
                         )
-                        (let* 
-                            (
-                                ($prevState (car-atom (collapse (match (afSnap) (prevState $x) $x))))
-                                ($currState (car-atom (collapse (match (afSnap) (currState $x) $x))))
-                                ($retentionValue (contextRetention $prevState $currState))
-                                ($afResource (afResourceUsage))
-                                ($stiConc (stiConcentration))
-                                ($linkDen (linkDensity))
-                                ($connRatio (connectionRatio))
-                                ($stiEntropy (preallocationSpace))
-                                ($pcorr (correlation))
-                                ($modulation (selectionModulation))
-                            )
-                            (
-                                (println! (retention $retentionValue))
-                                (write_metrics_wrapper $counter $now true $afResource $stiConc $linkDen $connRatio $stiEntropy $retentionValue $pcorr $modulation)
-                            )
-                        )
+                        (logCurrStateMetrics $counter)
                     )
                     (
                         (println! (agent not called))
-                        (write_metrics_wrapper $counter $now false (afResourceUsage) (stiConcentration) (linkDensity) (connectionRatio) (preallocationSpace) 0.0 (correlation) (selectionModulation))
+                        (write_metrics_wrapper $counter (afResourceUsage) (stiConcentration) (linkDensity) (connectionRatio) (preallocationSpace) 0.0 (correlation) (selectionModulation))
                     )
                 )
                 ; (py-call (time.sleep 5.0))

--- a/experiments/experiment.metta
+++ b/experiments/experiment.metta
@@ -102,6 +102,9 @@
 !(println! (sti concentration (stiConcentration)))
 !(println! (link density (linkDensity)))
 
+!(println! (Connection Ratio (connectionRatio)))
+!(println! (Normalized STI Entropy (preallocationSpace)))
+
 !(println! (retention (contextRetention
         (car-atom (collapse (match &afSnap (prevState $x) $x)))
         (car-atom (collapse (match &afSnap (currState $x) $x)))

--- a/experiments/logger.metta
+++ b/experiments/logger.metta
@@ -3,8 +3,8 @@
         (py-call (logger.write_to_csv $afAtoms))
 )
 
-(= (write_metrics_wrapper $counter $token $batchCalled $afResource $stiConcentration $linkDensity $connectionRatio $normalizedStiEntropy $retention $pCorrelation $modulation)
-    (py-call (logger.write_metrics_row $counter $token $batchCalled $afResource $stiConcentration $linkDensity $connectionRatio $normalizedStiEntropy $retention $pCorrelation $modulation))
+(= (write_metrics_wrapper $counter $afResource $stiConcentration $linkDensity $connectionRatio $normalizedStiEntropy $retention $pCorrelation $modulation)
+    (py-call (logger.write_metrics_row $counter $afResource $stiConcentration $linkDensity $connectionRatio $normalizedStiEntropy $retention $pCorrelation $modulation))
 )
 
 (= (AFsnapshot $afAtoms)

--- a/experiments/logger.metta
+++ b/experiments/logger.metta
@@ -3,6 +3,10 @@
         (py-call (logger.write_to_csv $afAtoms))
 )
 
+(= (write_metrics_wrapper $counter $token $batchCalled $afResource $stiConcentration $linkDensity $connectionRatio $normalizedStiEntropy $retention $pCorrelation $modulation)
+    (py-call (logger.write_metrics_row $counter $token $batchCalled $afResource $stiConcentration $linkDensity $connectionRatio $normalizedStiEntropy $retention $pCorrelation $modulation))
+)
+
 (= (AFsnapshot $afAtoms)
     (if (== $afAtoms ())
         ()

--- a/experiments/plot.py
+++ b/experiments/plot.py
@@ -7,10 +7,19 @@ import plotly.express as px
 import json
 import sys
 
+
+def resolve_output_root(path_like: Union[str, Path]) -> Path:
+    path = Path(path_like).resolve()
+    if path.is_file():
+        if path.name in {"output.csv", "metrics.csv"} and path.parent.name == "output":
+            return path.parent.parent
+        return path.parent
+    return path
+
 class Plotter:
 
     def __init__(self, output_path: Union[str, Path]):
-        self.output_path = Path(output_path).resolve()
+        self.output_path = resolve_output_root(output_path)
         self.data_path = self.get_data_path()
         self.params = self.read_params()
         self.categories = self.create_category()
@@ -127,16 +136,130 @@ class Plotter:
         except Exception as e:
             print("Plotly interactive plot failed:", e)
 
+
+class MetricsPlotter:
+
+    METRIC_COLUMNS = [
+        "af_resource",
+        "sti_concentration",
+        "link_density",
+        "connection_ratio",
+        "normalized_sti_entropy",
+        "retention",
+        "p_correlation",
+        "modulation",
+    ]
+    RESAMPLE_RULE = "15s"
+
+    def __init__(self, output_path: Union[str, Path]):
+        self.output_path = resolve_output_root(output_path)
+        self.metrics_path = self.get_metrics_path()
+        self.data_frame = self.read_metrics_csv()
+        self.plot()
+
+    def get_metrics_path(self) -> Path:
+        metrics_path = self.output_path / "output" / "metrics.csv"
+        if not metrics_path.exists():
+            raise FileNotFoundError(f"No {metrics_path} found")
+        return metrics_path
+
+    def read_metrics_csv(self) -> pd.DataFrame:
+        df = pd.read_csv(self.metrics_path, parse_dates=["timestamp"])
+        for column in self.METRIC_COLUMNS + ["counter"]:
+            if column in df.columns:
+                df[column] = pd.to_numeric(df[column], errors="coerce")
+
+        available = [column for column in self.METRIC_COLUMNS if column in df.columns]
+        if not available:
+            raise ValueError("No expected metric columns found in metrics.csv")
+
+        df = df[["timestamp", "counter", *available]].copy()
+        return df
+
+    def plot(self) -> None:
+        df = self.data_frame
+        metric_columns = [column for column in self.METRIC_COLUMNS if column in df.columns]
+
+        plot_df = df.dropna(subset=metric_columns)
+        if "timestamp" in plot_df.columns:
+            grouped = (
+                plot_df.set_index("timestamp")[metric_columns]
+                .resample(self.RESAMPLE_RULE)
+                .mean()
+                .dropna(how="all")
+                .reset_index()
+            )
+            x_axis = "timestamp"
+        else:
+            grouped = plot_df[["counter", *metric_columns]].copy()
+            x_axis = "counter"
+
+        smoothed = grouped[metric_columns].rolling(window=3, min_periods=1).mean()
+        smoothed[x_axis] = grouped[x_axis].values
+
+        n_cols = 2
+        n_rows = (len(metric_columns) + n_cols - 1) // n_cols
+        fig, axs = plt.subplots(n_rows, n_cols, figsize=(16, max(6, n_rows * 2.8)), sharex=True)
+        axs = axs.flatten()
+
+        colors = sns.color_palette("tab10", n_colors=len(metric_columns))
+
+        for idx, (metric, color) in enumerate(zip(metric_columns, colors)):
+            axs[idx].plot(
+                smoothed[x_axis],
+                smoothed[metric],
+                color=color,
+                linewidth=1.2,
+                alpha=0.95,
+            )
+            axs[idx].set_title(metric, fontsize=11)
+            axs[idx].grid(True, linestyle="--", alpha=0.35)
+
+        for idx in range(len(metric_columns), len(axs)):
+            fig.delaxes(axs[idx])
+
+        fig.suptitle("Evaluation Metrics Over Iterations", fontsize=14)
+        fig.supxlabel(
+            "Iteration Counter" if x_axis == "counter" else f"Timestamp ({self.RESAMPLE_RULE} bins)",
+            fontsize=12,
+        )
+        fig.supylabel("Metric Value", fontsize=12)
+        plt.tight_layout(rect=[0, 0.03, 1, 0.95])
+
+        png_path = self.output_path / "output" / "metrics_plot_faceted.png"
+        plt.savefig(png_path)
+        print("Metrics faceted plot saved to", png_path)
+
+        try:
+            melted = smoothed.melt(id_vars=x_axis, var_name="Metric", value_name="Value")
+            fig = px.line(
+                melted,
+                x=x_axis,
+                y="Value",
+                color="Metric",
+                title="Interactive Evaluation Metrics Over Iterations",
+            )
+            html_path = self.output_path / "output" / "metrics_plot_interactive.html"
+            fig.write_html(str(html_path))
+            print("Metrics interactive plot saved to", html_path)
+        except Exception as error:
+            print("Plotly metrics plot failed:", error)
+
 if __name__ == "__main__":
     base_dir = Path(__file__).parent.resolve() 
     if len(sys.argv) >= 2:
-        output_csv = sys.argv[1:]
+        targets = sys.argv[1:]
     else:
-        output_csv = list(base_dir.glob("**/output.csv"))
+        targets = sorted({str(path.parent.parent) for path in base_dir.glob("**/output/output.csv")})
 
-    for output in output_csv:
+    for target in targets:
+        root = resolve_output_root(target)
         try:
-            Plotter(output)
-        except Exception as e:
-            print(f"caught error: {e} while processing {output}")
-            continue
+            Plotter(root)
+        except Exception as error:
+            print(f"category plot skipped for {root}: {error}")
+
+        try:
+            MetricsPlotter(root)
+        except Exception as error:
+            print(f"metrics plot skipped for {root}: {error}")

--- a/experiments/plot.py
+++ b/experiments/plot.py
@@ -180,10 +180,9 @@ class MetricsPlotter:
         df = self.data_frame
         metric_columns = [column for column in self.METRIC_COLUMNS if column in df.columns]
 
-        plot_df = df.dropna(subset=metric_columns)
-        if "timestamp" in plot_df.columns:
+        if "timestamp" in df.columns:
             grouped = (
-                plot_df.set_index("timestamp")[metric_columns]
+                df.set_index("timestamp")[metric_columns]
                 .resample(self.RESAMPLE_RULE)
                 .mean()
                 .dropna(how="all")
@@ -191,11 +190,8 @@ class MetricsPlotter:
             )
             x_axis = "timestamp"
         else:
-            grouped = plot_df[["counter", *metric_columns]].copy()
+            grouped = df[["counter", *metric_columns]].copy()
             x_axis = "counter"
-
-        smoothed = grouped[metric_columns].rolling(window=3, min_periods=1).mean()
-        smoothed[x_axis] = grouped[x_axis].values
 
         n_cols = 2
         n_rows = (len(metric_columns) + n_cols - 1) // n_cols
@@ -205,9 +201,16 @@ class MetricsPlotter:
         colors = sns.color_palette("tab10", n_colors=len(metric_columns))
 
         for idx, (metric, color) in enumerate(zip(metric_columns, colors)):
+            series = grouped[[x_axis, metric]].dropna(subset=[metric]).copy()
+            if series.empty:
+                axs[idx].set_title(metric, fontsize=11)
+                axs[idx].grid(True, linestyle="--", alpha=0.35)
+                continue
+
+            series[metric] = series[metric].rolling(window=3, min_periods=1).mean()
             axs[idx].plot(
-                smoothed[x_axis],
-                smoothed[metric],
+                series[x_axis],
+                series[metric],
                 color=color,
                 linewidth=1.2,
                 alpha=0.95,
@@ -231,7 +234,20 @@ class MetricsPlotter:
         print("Metrics faceted plot saved to", png_path)
 
         try:
-            melted = smoothed.melt(id_vars=x_axis, var_name="Metric", value_name="Value")
+            long_frames = []
+            for metric in metric_columns:
+                series = grouped[[x_axis, metric]].dropna(subset=[metric]).copy()
+                if series.empty:
+                    continue
+                series[metric] = series[metric].rolling(window=3, min_periods=1).mean()
+                series = series.rename(columns={metric: "Value"})
+                series["Metric"] = metric
+                long_frames.append(series[[x_axis, "Metric", "Value"]])
+
+            if not long_frames:
+                raise ValueError("No metric data available for interactive plotting")
+
+            melted = pd.concat(long_frames, ignore_index=True)
             fig = px.line(
                 melted,
                 x=x_axis,

--- a/experiments/utils/logger.py
+++ b/experiments/utils/logger.py
@@ -29,6 +29,7 @@ START_LOGGER_FLAG = False
 LOGGING_DIRECTORY = None
 SETTING_PATH = None
 CSV_PATH = None
+METRICS_PATH = None
 
 
 def start_logger(directory):
@@ -37,7 +38,7 @@ def start_logger(directory):
     `directory` may be a string path or an object exposing `get_name()`.
     Returns a Hyperon-style empty result.
     """
-    global START_LOGGER_FLAG, LOGGING_DIRECTORY, SETTING_PATH, CSV_PATH
+    global START_LOGGER_FLAG, LOGGING_DIRECTORY, SETTING_PATH, CSV_PATH, METRICS_PATH
 
     # Accept either string path or an object with get_name()
     if isinstance(directory, str):
@@ -62,11 +63,13 @@ def start_logger(directory):
 
     SETTING_PATH = log_dir / "settings.json"
     CSV_PATH = log_dir / "output.csv"
+    METRICS_PATH = log_dir / "metrics.csv"
 
 
 
     SETTING_PATH.write_text("")
     CSV_PATH.write_text("")
+    METRICS_PATH.write_text("")
 
     START_LOGGER_FLAG = True
     return ['started']
@@ -123,4 +126,53 @@ def write_to_csv(afatoms):
         return ['not written']
 
     write_string_to_csv(str(CSV_PATH), afatoms)
+    return ['wrote']
+
+
+def write_metrics_row(counter, token, batch_called, af_resource, sti_concentration, link_density,
+                      connection_ratio, normalized_sti_entropy, retention, p_correlation, modulation):
+    
+    # Append one metrics row per iteration to metrics.csv.
+
+    global START_LOGGER_FLAG, METRICS_PATH
+
+    if not START_LOGGER_FLAG or METRICS_PATH is None:
+        return ['not written']
+
+    header = [
+        "timestamp",
+        "counter",
+        "token",
+        "batch_called",
+        "af_resource",
+        "sti_concentration",
+        "link_density",
+        "connection_ratio",
+        "normalized_sti_entropy",
+        "retention",
+        "p_correlation",
+        "modulation",
+    ]
+
+    row = [
+        str(datetime.now()),
+        str(counter),
+        str(token),
+        str(batch_called),
+        str(af_resource),
+        str(sti_concentration),
+        str(link_density),
+        str(connection_ratio),
+        str(normalized_sti_entropy),
+        str(retention),
+        str(p_correlation),
+        str(modulation),
+    ]
+
+    with open(METRICS_PATH, 'a', newline='', encoding='utf-8') as file:
+        writer = csv.writer(file)
+        if os.path.getsize(METRICS_PATH) == 0:
+            writer.writerow(header)
+        writer.writerow(row)
+
     return ['wrote']

--- a/experiments/utils/logger.py
+++ b/experiments/utils/logger.py
@@ -129,7 +129,7 @@ def write_to_csv(afatoms):
     return ['wrote']
 
 
-def write_metrics_row(counter, token, batch_called, af_resource, sti_concentration, link_density,
+def write_metrics_row(counter, af_resource, sti_concentration, link_density,
                       connection_ratio, normalized_sti_entropy, retention, p_correlation, modulation):
     
     # Append one metrics row per iteration to metrics.csv.
@@ -142,8 +142,6 @@ def write_metrics_row(counter, token, batch_called, af_resource, sti_concentrati
     header = [
         "timestamp",
         "counter",
-        "token",
-        "batch_called",
         "af_resource",
         "sti_concentration",
         "link_density",
@@ -157,8 +155,6 @@ def write_metrics_row(counter, token, batch_called, af_resource, sti_concentrati
     row = [
         str(datetime.now()),
         str(counter),
-        str(token),
-        str(batch_called),
         str(af_resource),
         str(sti_concentration),
         str(link_density),


### PR DESCRIPTION
This pull request introduces several new metrics and utility functions to the `attention-bank/synapse/ratio.metta` file, enhancing the analysis of network structure and performance. It also updates the experiment script to print the new metrics. The most significant changes are the addition of functions for connection ratio, normalized STI entropy, internal coherence, and placeholders for topological invariants.

**New metrics and analysis functions:**

* Added `connectionRatio` to compute the proportion of internal links among all Hebbian links in the network.
* Introduced `preallocationSpace` to calculate the normalized entropy of STI values, giving insight into the distribution of activation.
* Implemented `moduleInternalCoherence` and `globalCoordination` to assess the internal and global coherence of network modules.
* Added placeholders for topological invariants (Betti numbers, triangle counting) and a `TopologyReport` structure for future persistent homology analysis.

**Utility and support functions:**

* Added helper functions such as `getLinkTarget`, `isInternalLink`, `log2-math`, `entropyTerm`, and `averageList` to support the new metrics.
* Implemented `cognitiveMaintenance` for updating a running mean of context retention between states.

**Experiment script updates:**

* Updated `experiments/experiment.metta` to print out the new `connectionRatio` and `preallocationSpace` metrics for better observability during experiments.

**Refactoring and consistency:**

* Changed calls from `getAfAtoms` to `getAllAtomsWithBins` in `correlation` and `selectionModulation` for consistency and likely improved atom selection. [[1]](diffhunk://#diff-3eef50be27bfa5cdd6a3e06f36e30afee9678353aeefce5938aa007c9fa02d4eL101-R101) [[2]](diffhunk://#diff-3eef50be27bfa5cdd6a3e06f36e30afee9678353aeefce5938aa007c9fa02d4eL126-R126)