### PR TITLE
Feat/redundancy degradation

### DIFF
--- a/attention-bank/synapse/ratio.metta
+++ b/attention-bank/synapse/ratio.metta
@@ -491,6 +491,30 @@
     )
 )
 
+(= (getRedundancyDegradation $index)
+    (let* (
+        ($snapshot (get-cip-snapshots $index))
+        ($currMetrics (getMetricsFromSnapshot $snapshot))
+        ($baselineData (get_baseline_redundancy_data $index))
+        ($baselinePerf (car-atom $baselineData))
+        ($baselineCost (car-atom (cdr-atom $baselineData)))
+        
+        ($currCost (+ (getMetrics afResource $currMetrics) (+ (getMetrics sticoncentration $currMetrics) (getMetrics linkdensity $currMetrics))))
+        ($currEff (getMetrics effectiveness $currMetrics))
+        ($currPerf (* $currEff $currCost))
+        
+        ($overhead (- $currCost $baselineCost))
+    )
+    (if (<= $baselineCost 0.0)
+        0.0
+        (if (> (abs-math $overhead) 0.0001)
+            (/ (- $baselinePerf $currPerf) $overhead)
+            0.0
+        )
+    )
+    )
+)
+
 ; ## Topological Analysis
 
 ; persistent homology will be implemented here

--- a/experiments/experiment.metta
+++ b/experiments/experiment.metta
@@ -65,8 +65,9 @@
                 ((CIPSnapshot $index $time $afAtoms $metrice) $cip)
                 (($afResource $stiConcentration $linkDensity $connectionRatio $preallocation $cognitiveSynergy $modulation $coordination $contextRetention $cognitiveMaintenance $effectiveness) $metrice)
                 ($gainedEfficiency (getGainedEfficiency $index))
+                ($redundancyDegradation (getRedundancyDegradation $index))
         )
-        (write_metrics_wrapper $index $time $afAtoms $afResource $stiConcentration $linkDensity $connectionRatio $preallocation $cognitiveSynergy $modulation $coordination $contextRetention $cognitiveMaintenance $effectiveness $gainedEfficiency)
+        (write_metrics_wrapper $index $time $afAtoms $afResource $stiConcentration $linkDensity $connectionRatio $preallocation $cognitiveSynergy $modulation $coordination $contextRetention $cognitiveMaintenance $effectiveness $gainedEfficiency $redundancyDegradation)
     )
 )
 

--- a/experiments/logger.metta
+++ b/experiments/logger.metta
@@ -5,7 +5,7 @@
 
 (= (write_metrics_wrapper 
     $counter $time $af_atoms $afResource $stiConcentration $linkDensity $connectionRatio 
-    $preallocation $cognitiveSynergy $modulation $coordination $contextRetention $cognitiveMaintenance $effectiveness $gainedEfficiency)
+    $preallocation $cognitiveSynergy $modulation $coordination $contextRetention $cognitiveMaintenance $effectiveness $gainedEfficiency $redundancyDegradation)
     (py-call (logger.write_metrics_row 
                 $counter 
                 $time 
@@ -21,7 +21,8 @@
                 $contextRetention 
                 $cognitiveMaintenance
                 $effectiveness
-                $gainedEfficiency)
+                $gainedEfficiency
+                $redundancyDegradation)
     )
 )
 
@@ -35,6 +36,10 @@
 
 (= (get_baseline_effectiveness $index)
     (py-call (logger.get_baseline_effectiveness $index))
+)
+
+(= (get_baseline_redundancy_data $index)
+    (py-call (logger.get_baseline_redundancy_data $index))
 )
 
 

--- a/experiments/plot.py
+++ b/experiments/plot.py
@@ -151,6 +151,7 @@ class MetricsPlotter:
         "cognitive_maintenance",
         "effectiveness",
         "gained_efficiency",
+        "redundancy_degradation",
     ]
     RESAMPLE_RULE = "15s"
 

--- a/experiments/utils/create_noisy_dataset.py
+++ b/experiments/utils/create_noisy_dataset.py
@@ -1,0 +1,35 @@
+import sys
+import random
+import re
+
+if len(sys.argv) < 3:
+    print("Usage: python create_noisy_dataset.py <input.metta> <output.metta> [noise_ratio]")
+    sys.exit(1)
+
+input_file = sys.argv[1]
+output_file = sys.argv[2]
+noise_ratio = float(sys.argv[3]) if len(sys.argv) > 3 else 0.2
+
+print(f"Reading from {input_file}...")
+
+duplicated_count = 0
+total_count = 0
+
+with open(input_file, "r", encoding="utf-8") as fin, open(output_file, "w", encoding="utf-8") as fout:
+    for line in fin:
+        fout.write(line)
+        total_count += 1
+        
+        if line.strip() and random.random() < noise_ratio:
+            match = re.match(r'^\(([^ \)]+)', line)
+            if match:
+                root_name = match.group(1)
+                redundant_name = f"{root_name}_redundant"
+                
+                noisy_line = re.sub(r'(?<=\s|\()' + re.escape(root_name) + r'(?=\s|\))', redundant_name, line)
+                fout.write(noisy_line)
+                duplicated_count += 1
+
+print(f"Done! Generated {output_file}.")
+print(f"Total original atoms: {total_count}")
+print(f"Redundant atoms injected: {duplicated_count}")

--- a/experiments/utils/create_noisy_dataset.py
+++ b/experiments/utils/create_noisy_dataset.py
@@ -1,6 +1,5 @@
-import sys
 import random
-import re
+import sys
 
 def generate_noisy_dataset(input_file, output_file, noise_ratio=0.2):
     print(f"Reading from {input_file}...")
@@ -8,20 +7,16 @@ def generate_noisy_dataset(input_file, output_file, noise_ratio=0.2):
     duplicated_count = 0
     total_count = 0
 
-    with open(input_file, "r", encoding="utf-8") as fin, open(output_file, "w", encoding="utf-8") as fout:
+    with open(input_file, "r", encoding="utf-8") as fin, \
+         open(output_file, "w", encoding="utf-8") as fout:
+
         for line in fin:
             fout.write(line)
             total_count += 1
-            
+
             if line.strip() and random.random() < noise_ratio:
-                match = re.match(r'^\(([^ \)]+)', line)
-                if match:
-                    root_name = match.group(1)
-                    redundant_name = f"{root_name}_redundant"
-                    
-                    noisy_line = re.sub(r'(?<=\s|\()' + re.escape(root_name) + r'(?=\s|\))', redundant_name, line)
-                    fout.write(noisy_line)
-                    duplicated_count += 1
+                fout.write(line)
+                duplicated_count += 1
 
     return duplicated_count, total_count
 

--- a/experiments/utils/create_noisy_dataset.py
+++ b/experiments/utils/create_noisy_dataset.py
@@ -2,34 +2,36 @@ import sys
 import random
 import re
 
-if len(sys.argv) < 3:
-    print("Usage: python create_noisy_dataset.py <input.metta> <output.metta> [noise_ratio]")
-    sys.exit(1)
+def generate_noisy_dataset(input_file, output_file, noise_ratio=0.2):
+    print(f"Reading from {input_file}...")
 
-input_file = sys.argv[1]
-output_file = sys.argv[2]
-noise_ratio = float(sys.argv[3]) if len(sys.argv) > 3 else 0.2
+    duplicated_count = 0
+    total_count = 0
 
-print(f"Reading from {input_file}...")
+    with open(input_file, "r", encoding="utf-8") as fin, open(output_file, "w", encoding="utf-8") as fout:
+        for line in fin:
+            fout.write(line)
+            total_count += 1
+            
+            if line.strip() and random.random() < noise_ratio:
+                match = re.match(r'^\(([^ \)]+)', line)
+                if match:
+                    root_name = match.group(1)
+                    redundant_name = f"{root_name}_redundant"
+                    
+                    noisy_line = re.sub(r'(?<=\s|\()' + re.escape(root_name) + r'(?=\s|\))', redundant_name, line)
+                    fout.write(noisy_line)
+                    duplicated_count += 1
 
-duplicated_count = 0
-total_count = 0
+    return duplicated_count, total_count
 
-with open(input_file, "r", encoding="utf-8") as fin, open(output_file, "w", encoding="utf-8") as fout:
-    for line in fin:
-        fout.write(line)
-        total_count += 1
-        
-        if line.strip() and random.random() < noise_ratio:
-            match = re.match(r'^\(([^ \)]+)', line)
-            if match:
-                root_name = match.group(1)
-                redundant_name = f"{root_name}_redundant"
-                
-                noisy_line = re.sub(r'(?<=\s|\()' + re.escape(root_name) + r'(?=\s|\))', redundant_name, line)
-                fout.write(noisy_line)
-                duplicated_count += 1
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: python create_noisy_dataset.py <input.metta> <output.metta> [noise_ratio]")
+        sys.exit(1)
 
-print(f"Done! Generated {output_file}.")
-print(f"Total original atoms: {total_count}")
-print(f"Redundant atoms injected: {duplicated_count}")
+    in_file = sys.argv[1]
+    out_file = sys.argv[2]
+    ratio = float(sys.argv[3]) if len(sys.argv) > 3 else 0.2
+
+    generate_noisy_dataset(in_file, out_file, ratio)

--- a/experiments/utils/logger.py
+++ b/experiments/utils/logger.py
@@ -220,17 +220,37 @@ def write_cip_row(index, time, af_atoms, metrices):
 
     return ['wrote']
 
+BASELINE_METRICS_CACHE = None
+REDUNDANCY_BASELINE_CACHE = None
+
 def _load_baseline_cache():
     global BASELINE_METRICS_CACHE
     if BASELINE_METRICS_CACHE is None:
         csv_path = LOGGING_DIRECTORY / "output" / "baseline_metrics.csv"
+        # Fallback to old folder structure
+        old_path = LOGGING_DIRECTORY / "baseline" / "output" / "metrics.csv"
+        
+        target_path = csv_path if csv_path.exists() else old_path
 
-        if csv_path.exists():
-            with open(csv_path, 'r') as f:
+        if target_path.exists():
+            with open(target_path, 'r') as f:
                 reader = csv.DictReader(f)
                 BASELINE_METRICS_CACHE = list(reader)
         else:
             BASELINE_METRICS_CACHE = []
+
+def _load_redundancy_baseline_cache():
+    global REDUNDANCY_BASELINE_CACHE
+
+    if REDUNDANCY_BASELINE_CACHE is None:
+        csv_path = LOGGING_DIRECTORY / "output" / "redundancy_baseline_metrics.csv"
+
+        if csv_path.exists():
+            with open(csv_path, "r") as f:
+                reader = csv.DictReader(f)
+                REDUNDANCY_BASELINE_CACHE = list(reader)
+        else:
+            REDUNDANCY_BASELINE_CACHE = []
 
 def get_baseline_effectiveness(index):
     """Load baseline metrics.csv and return the effectiveness at the given step index."""
@@ -241,11 +261,11 @@ def get_baseline_effectiveness(index):
     return 0.0
 
 def get_baseline_redundancy_data(index):
-    """Returns a hyperon/MeTTa tuple: (baseline_perf, baseline_cost)"""
-    _load_baseline_cache()
+    """Returns a tuple: (baseline_perf, baseline_cost)"""
+    _load_redundancy_baseline_cache()
     idx = int(index)
-    if 0 <= idx < len(BASELINE_METRICS_CACHE):
-        row = BASELINE_METRICS_CACHE[idx]
+    if 0 <= idx < len(REDUNDANCY_BASELINE_CACHE):
+        row = REDUNDANCY_BASELINE_CACHE[idx]
         af_res = float(row.get('af_resource', 0.0))
         sti_conc = float(row.get('sti_concentration', 0.0))
         link_den = float(row.get('link_density', 0.0))

--- a/experiments/utils/logger.py
+++ b/experiments/utils/logger.py
@@ -30,7 +30,7 @@ LOGGING_DIRECTORY = None
 SETTING_PATH = None
 CSV_PATH = None
 METRICS_PATH = None
-BASELINE_EFFECTIVENESS_CACHE = None
+BASELINE_METRICS_CACHE = None
 
 
 def start_logger(directory):
@@ -132,7 +132,7 @@ def write_to_csv(afatoms):
 
 def write_metrics_row(counter, time, af_atoms, af_resource, sti_concentration, link_density, coherance,
                       connection_ratio, normalized_sti_entropy, retention, p_correlation, modulation,
-                      global_coordination, effectiveness, gained_efficiency=0.0):
+                      global_coordination, effectiveness, gained_efficiency=0.0, redundancy_degradation=0.0):
     
     # Append one metrics row per iteration to metrics.csv.
 
@@ -156,6 +156,7 @@ def write_metrics_row(counter, time, af_atoms, af_resource, sti_concentration, l
         "cognitive_maintenance",
         "effectiveness",
         "gained_efficiency",
+        "redundancy_degradation",
         "af_atoms",
     ]
 
@@ -174,6 +175,7 @@ def write_metrics_row(counter, time, af_atoms, af_resource, sti_concentration, l
         str(global_coordination[1]),
         str(effectiveness[1]),
         str(gained_efficiency),
+        str(redundancy_degradation),
         str(af_atoms),
     ]
 
@@ -218,22 +220,40 @@ def write_cip_row(index, time, af_atoms, metrices):
 
     return ['wrote']
 
-def get_baseline_effectiveness(index):
-    """Load baseline_metrics.csv and return the effectiveness at the given step index."""
-    global BASELINE_EFFECTIVENESS_CACHE
-
-    if BASELINE_EFFECTIVENESS_CACHE is None:
-        csv_path = Path(__file__).parent.parent / "output" / "baseline_metrics.csv"
+def _load_baseline_cache():
+    global BASELINE_METRICS_CACHE
+    if BASELINE_METRICS_CACHE is None:
+        csv_path = LOGGING_DIRECTORY / "output" / "baseline_metrics.csv"
 
         if csv_path.exists():
             with open(csv_path, 'r') as f:
                 reader = csv.DictReader(f)
-                BASELINE_EFFECTIVENESS_CACHE = [float(row['effectiveness']) for row in reader]
+                BASELINE_METRICS_CACHE = list(reader)
         else:
-            BASELINE_EFFECTIVENESS_CACHE = []
+            BASELINE_METRICS_CACHE = []
 
+def get_baseline_effectiveness(index):
+    """Load baseline metrics.csv and return the effectiveness at the given step index."""
+    _load_baseline_cache()
     idx = int(index)
-    if 0 <= idx < len(BASELINE_EFFECTIVENESS_CACHE):
-        return float(BASELINE_EFFECTIVENESS_CACHE[idx])
+    if 0 <= idx < len(BASELINE_METRICS_CACHE):
+        return float(BASELINE_METRICS_CACHE[idx].get('effectiveness', 0.0))
     return 0.0
 
+def get_baseline_redundancy_data(index):
+    """Returns a hyperon/MeTTa tuple: (baseline_perf, baseline_cost)"""
+    _load_baseline_cache()
+    idx = int(index)
+    if 0 <= idx < len(BASELINE_METRICS_CACHE):
+        row = BASELINE_METRICS_CACHE[idx]
+        af_res = float(row.get('af_resource', 0.0))
+        sti_conc = float(row.get('sti_concentration', 0.0))
+        link_den = float(row.get('link_density', 0.0))
+        effectiveness = float(row.get('effectiveness', 0.0))
+        
+        # Reverse engineer cost and performance
+        baseline_cost = af_res + sti_conc + link_den
+        baseline_perf = effectiveness * baseline_cost
+        
+        return [baseline_perf, baseline_cost]
+    return [0.0, 0.0]


### PR DESCRIPTION
This pull request introduces a new "redundancy degradation" metric to the experiment framework, enabling the calculation, logging, and plotting of this value alongside existing metrics. It also adds a utility script for generating noisy datasets and refactors baseline metric handling for greater flexibility.

**Redundancy Degradation Metric Integration:**

* Added a new function `getRedundancyDegradation` in `ratio.metta` to compute redundancy degradation based on current and baseline performance/cost, and integrated its calculation into the experiment pipeline (`experiment.metta`). 
* Updated the logging infrastructure (`logger.metta`, `logger.py`) to record the new `redundancy_degradation` metric, including changes to the metrics row writer and CSV headers. able metric.

**Baseline Metrics Handling Improvements:**

* Refactored baseline metric caching and access in `logger.py` to support retrieval of both effectiveness and redundancy-related baseline data, enabling more robust metric calculations. 

**Utility Script Addition:**

* Added `create_noisy_dataset.py`, a script to generate noisy datasets by duplicating and modifying lines in a `.metta` file, useful for testing robustness to redundancy.