### PR TITLE
Profiling of operations inside attention and synapse of metta-attention

### DIFF
--- a/attention/ForgettingAgent/ForgettingAgent.metta
+++ b/attention/ForgettingAgent/ForgettingAgent.metta
@@ -155,7 +155,7 @@
 ; return: True if atom can be removed else False
 (: atomBelowForgetThreshold (-> Atom Number Number Bool))
 (= (atomBelowForgetThreshold $head $removalAmount $count) 
-	(if (and (<= (getLti $head) (forgetThreshold)) (< $count $removalAmount))
+	(if (and (<= (getLti $head) (getAttentionParam FORGET_THRESHOLD)) (< $count $removalAmount))
 		(if (== (getVlti $head) 0.0 ) 
 			True
 			False

--- a/attention/HebbianCreationAgent/HebbianCreationAgent.metta
+++ b/attention/HebbianCreationAgent/HebbianCreationAgent.metta
@@ -74,7 +74,7 @@
         ()
         (let*
             (
-                ($randomAtom (getRandomAtomInAF $afAtoms))
+                ($randomAtom (getRandomAtomInAF))
                 ($incomingSet (getIncomingSetByType $randomAtom HEBBIAN_LINK)) 
                 ; ($p (println! (incoming $incomingSet)))
                 ($x (remove-atom &typespace (car-atom $incomingSet)))
@@ -121,7 +121,7 @@
 (= (generateRandom $farLinks $afAtoms)
     (if (<= $farLinks 0)
         ()
-        (superpose ((getRandomAtomNotInAF $afAtoms) (generateRandom (- $farLinks 1) $afAtoms)))
+        (superpose ((getRandomAtomNotInAF) (generateRandom (- $farLinks 1) $afAtoms)))
     )
 )
 

--- a/benchmarks/agents_profile_result.md
+++ b/benchmarks/agents_profile_result.md
@@ -1,0 +1,92 @@
+# Profile Results
+
+Only application-level functions are shown (Prolog built-ins and MeTTa runtime internals excluded).
+
+
+## 1. Rent Collection 
+
+| Function                  | Calls     | Self Time     | Children Time | Total Time    |
+|---------------------------|-----------|---------------|---------------|---------------|
+| `setAv`                   | 10,016    | 0.04s ( 0.5%) | 6.80s (76.2%) | 6.84s (76.7%) |
+| `updateAf`                | 10,014    | 0.06s ( 0.7%) | 2.34s (26.2%) | 2.40s (26.9%) |
+| `attentionValueChanged`   | 7,010     | 0.02s ( 0.2%) | 1.68s (18.8%) | 1.70s (19.0%) |
+| `applyRent`               | 4,000     | 0.02s ( 0.2%) | 3.50s (39.2%) | 3.52s (39.4%) |
+| `getValueType`            | 51,066    | 0.05s ( 0.5%) | 1.18s (13.2%) | 1.23s (13.7%) |
+| `getAv`                   | 37,055    | 0.02s ( 0.2%) | 0.85s ( 9.5%) | 0.87s ( 9.7%) |
+| `println!`                | 7,010     | 0.01s ( 0.1%) | 1.45s (16.3%) | 1.46s (16.4%) |
+| `importanceBin`           | 9,010     | 0.02s ( 0.2%) | 0.14s ( 1.6%) | 0.16s ( 1.8%) |
+| `collectRent`             | 1,502     | 0.01s ( 0.1%) | 1.37s (15.4%) | 1.38s (15.5%) |
+| `getLti`                  | 14,022    | 0.02s ( 0.2%) | 0.30s ( 3.3%) | 0.32s ( 3.5%) |
+| `updateMinAf`             | 7,010     | 0.04s ( 0.5%) | 0.20s ( 2.2%) | 0.24s ( 2.7%) |
+| `calculateLtiRent`        | 14,000    | 0.05s ( 0.5%) | 0.25s ( 2.8%) | 0.30s ( 3.3%) |
+| `calculateStiRent`        | 14,000    | 0.02s ( 0.2%) | 0.15s ( 1.7%) | 0.17s ( 1.9%) |
+| `findGroup`               | 4,002     | 0.01s ( 0.1%) | 0.03s ( 0.4%) | 0.04s ( 0.4%) |
+| `isAtomInAf`              | 10,013    | 0.01s ( 0.2%) | 0.02s ( 0.2%) | 0.03s ( 0.4%) |
+
+
+
+## 2. Importance Diffusion 
+
+| Function                          | Calls     | Self Time     | Children Time | Total Time    |
+|-----------------------------------|-----------|---------------|---------------|---------------|
+| `incidentAtoms`                   | 3,900     | 0.01s ( 0.2%) | 3.42s (69.0%) | 3.43s (69.2%) |
+| `diffuseAtom`                     | 1,601     | 0.01s ( 0.3%) | 0.57s (11.4%) | 0.58s (11.7%) |
+| `getValueType`                    | 38,545    | 0.01s ( 0.3%) | 0.53s (10.6%) | 0.54s (10.9%) |
+| `getStv`                          | 29,602    | 0.02s ( 0.4%) | 0.46s ( 9.2%) | 0.48s ( 9.6%) |
+| `probabilityVectorHebbianAjacent` | 4,800     | 0.01s ( 0.2%) | 0.14s ( 2.8%) | 0.15s ( 3.0%) |
+| `concatTuple`                     | 1,300     | 0.01s ( 0.2%) | 0.00s ( 0.0%) | 0.01s ( 0.2%) |
+| `hebbianDiffusionUsed`            | 1 (entry) | 0.02s ( 0.4%) | 0.05s ( 1.0%) | 0.07s ( 1.4%) |
+| `calcElapsedTime`                 | 1,401     | 0.01s ( 0.2%) | 0.02s ( 0.4%) | 0.03s ( 0.6%) |
+| `profileIncidentAtoms`            | 2,001     | 0.02s ( 0.3%) | 1.98s (39.8%) | 2.00s (40.1%) |
+| `profileProbabilityVectorHebbian` | 1         | 0.01s ( 0.2%) | 0.05s ( 1.1%) | 0.06s ( 1.3%) |
+| `profileProbabilityVectorIncident`| 1,001     | 0.01s ( 0.2%) | 0.71s (14.4%) | 0.72s (14.6%) |
+| `profileHebbianDiffusionUsed`     | 1         | 0.02s ( 0.4%) | 0.05s ( 1.0%) | 0.07s ( 1.4%) |
+| `profileFilteroset`               | 1         | 0.02s ( 0.3%) | 0.03s ( 0.6%) | 0.05s ( 0.9%) |
+
+
+
+## 3. Hebbain Updating 
+
+| Function                      | Calls     | Self Time     | Children Time | Total Time    |
+|-------------------------------|-----------|---------------|---------------|---------------|
+| `targetConjunction`           | 4,547     | 0.03s ( 1.1%) | 0.94s (31.6%) | 0.97s (32.7%) |
+| `getSti`                      | 9,099     | 0.04s ( 1.2%) | 0.57s (19.4%) | 0.61s (20.6%) |
+| `getValueType`                | 11,301    | 0.02s ( 0.7%) | 0.63s (21.3%) | 0.65s (22.0%) |
+| `getAv`                       | 9,651     | 0.02s ( 0.8%) | 0.57s (19.2%) | 0.59s (20.0%) |
+| `getNormalisedZeroToOneSTI`   | 9,094     | 0.05s ( 1.8%) | 0.23s ( 7.8%) | 0.28s ( 9.6%) |
+| `getAttentionParam`           | 18,759    | 0.03s ( 1.1%) | 0.12s ( 4.1%) | 0.15s ( 5.2%) |
+| `higherConfidenceMerge`       | 10,000    | 0.02s ( 0.6%) | 0.04s ( 1.4%) | 0.06s ( 2.0%) |
+| `mergeCalculation`            | 4,547     | 0.01s ( 0.2%) | 0.19s ( 6.3%) | 0.20s ( 6.5%) |
+| `updateHebbianLinks`          | 606       | 0.00s ( 0.1%) | 1.18s (39.8%) | 1.18s (39.9%) |
+| `bachUpdateHeb`               | 547       | 0.00s ( 0.1%) | 0.24s ( 8.2%) | 0.24s ( 8.3%) |
+| `profileMergeCalculation`     | 1         | 0.03s ( 1.1%) | 0.18s ( 6.0%) | 0.21s ( 7.1%) |
+| `profileTargetConjunction`    | 1         | 0.01s ( 0.4%) | 0.86s (29.2%) | 0.87s (29.6%) |
+| `getMinSTI`                   | 9,094     | 0.01s ( 0.5%) | 0.09s ( 3.1%) | 0.10s ( 3.6%) |
+
+
+
+## 4. Hebbain Creation 
+
+| Function                      | Calls     | Self Time     | Children Time | Total Time    |
+|-------------------------------|-----------|---------------|---------------|---------------|
+| `addHebbian` (hyp/batch spec) | 10,006    | 0.02s ( 0.6%) | 2.32s (82.8%) | 2.34s (83.4%) |
+| `bach-p` (addHebbian spec)    | 1,997     | 0.01s ( 0.3%) | 2.45s (87.5%) | 2.46s (87.8%) |
+| `batch` (addHebbian spec)     | 2,006     | 0.00s ( 0.2%) | 2.36s (84.4%) | 2.36s (84.6%) |
+| `localToFarLinks`             | 1,000     | 0.00s ( 0.1%) | 0.00s ( 0.0%) | 0.00s ( 0.1%) |
+| `first-k`                     | 2,000     | 0.01s ( 0.3%) | 0.01s ( 0.5%) | 0.02s ( 0.8%) |
+
+
+## 5. Forget Agent 
+
+| Function                    | Calls     | Self Time     | Children Time | Total Time    |
+|-----------------------------|-----------|---------------|---------------|---------------|
+| `getValueType`              | 99,545    | 0.03s ( 1.1%) | 1.39s (50.3%) | 1.42s (51.4%) |
+| `getAv`                     | 97,528    | 0.02s ( 0.8%) | 1.39s (50.4%) | 1.41s (51.2%) |
+| `getLti`                    | 91,014    | 0.04s ( 1.6%) | 1.25s (45.5%) | 1.29s (47.1%) |
+| `greaterThanLtiThenTV`      | 10,000    | 0.02s ( 0.6%) | 0.62s (22.5%) | 0.64s (23.1%) |
+| `updateAf`                  | 2,015     | 0.01s ( 0.4%) | 0.36s (13.2%) | 0.37s (13.6%) |
+| `lessThanLtiThenTV`         | 10,000    | 0.00s ( 0.1%) | 0.48s (17.3%) | 0.48s (17.4%) |
+| `profileLessThanLtiThenTV`  | 1         | 0.00s ( 0.1%) | 0.50s (18.0%) | 0.50s (18.1%) |
+| `updateMinAf`               | 1,012     | 0.01s ( 0.3%) | 0.01s ( 0.3%) | 0.02s ( 0.6%) |
+| `importanceBin`             | 1,012     | 0.01s ( 0.3%) | 0.03s ( 0.9%) | 0.04s ( 1.2%) |
+| `atomBelowForgetThreshold`  | 10,000    | 0.00s ( 0.1%) | 0.36s (13.2%) | 0.36s (13.3%) |

--- a/benchmarks/agents_profile_result.md
+++ b/benchmarks/agents_profile_result.md
@@ -1,6 +1,20 @@
-# Profile Results
+# Compiled Agent Profiling Report
 
-Only application-level functions are shown (Prolog built-ins and MeTTa runtime internals excluded).
+This report summarizes the profiling results across all five core attention agent
+**Note**: Only application-level functions are shown (Prolog built-ins and MeTTa runtime internals excluded).
+**NB**:all agents profile are executed separatley from other sub-metta files with 500 agent cycles.
+
+### Agent-Level Overview
+
+| Agent Benchmark | Total Time |
+|-----------------|------------|
+| **AFRent Collection** | **0.806s** |
+| **WARent Collection** | **0.331s** |
+| **AFImportance Diffusion** | **0.406s** |
+| **WAImportance Diffusion** | **0.534s** |
+| **Hebbian Updating** | **0.497s** |
+| **Hebbian Creation** | **14.995s** |
+| **Forgetting Agent** | **0.176s** |
 
 
 ## 1. Rent Collection 
@@ -23,6 +37,10 @@ Only application-level functions are shown (Prolog built-ins and MeTTa runtime i
 | `findGroup`               | 4,002     | 0.01s ( 0.1%) | 0.03s ( 0.4%) | 0.04s ( 0.4%) |
 | `isAtomInAf`              | 10,013    | 0.01s ( 0.2%) | 0.02s ( 0.2%) | 0.03s ( 0.4%) |
 
+- `AF Rent collection agent` total time:0.806 seconds. avg time per agent cycle: 0.806/500 seconds
+- `WA Rent collection agent` total time:0.331 seconds. avg time per agent cycle: 0.331/500 seconds
+---
+
 
 
 ## 2. Importance Diffusion 
@@ -43,6 +61,9 @@ Only application-level functions are shown (Prolog built-ins and MeTTa runtime i
 | `profileHebbianDiffusionUsed`     | 1         | 0.02s ( 0.4%) | 0.05s ( 1.0%) | 0.07s ( 1.4%) |
 | `profileFilteroset`               | 1         | 0.02s ( 0.3%) | 0.03s ( 0.6%) | 0.05s ( 0.9%) |
 
+- `AF importancediffusion agent` total time:0.406 seconds. avg time per agent cycle: 0.406/500 seconds
+- `WA importancediffusion agent` total time:0.534 seconds. avg time per agent cycle: 0.534/500 seconds
+---
 
 
 ## 3. Hebbain Updating 
@@ -63,6 +84,8 @@ Only application-level functions are shown (Prolog built-ins and MeTTa runtime i
 | `profileTargetConjunction`    | 1         | 0.01s ( 0.4%) | 0.86s (29.2%) | 0.87s (29.6%) |
 | `getMinSTI`                   | 9,094     | 0.01s ( 0.5%) | 0.09s ( 3.1%) | 0.10s ( 3.6%) |
 
+- `AF Hebbain Updating agent` total time:0.497 seconds. avg time per agent cycle: 0.497/500 seconds
+---
 
 
 ## 4. Hebbain Creation 
@@ -74,6 +97,9 @@ Only application-level functions are shown (Prolog built-ins and MeTTa runtime i
 | `batch` (addHebbian spec)     | 2,006     | 0.00s ( 0.2%) | 2.36s (84.4%) | 2.36s (84.6%) |
 | `localToFarLinks`             | 1,000     | 0.00s ( 0.1%) | 0.00s ( 0.0%) | 0.00s ( 0.1%) |
 | `first-k`                     | 2,000     | 0.01s ( 0.3%) | 0.01s ( 0.5%) | 0.02s ( 0.8%) |
+
+- `hebbian creation agent` agent time:14.995 seconds, avg time per agent cycle: 14.995/500 seconds
+---
 
 
 ## 5. Forget Agent 
@@ -90,3 +116,6 @@ Only application-level functions are shown (Prolog built-ins and MeTTa runtime i
 | `updateMinAf`               | 1,012     | 0.01s ( 0.3%) | 0.01s ( 0.3%) | 0.02s ( 0.6%) |
 | `importanceBin`             | 1,012     | 0.01s ( 0.3%) | 0.03s ( 0.9%) | 0.04s ( 1.2%) |
 | `atomBelowForgetThreshold`  | 10,000    | 0.00s ( 0.1%) | 0.36s (13.2%) | 0.36s (13.3%) |
+
+- `Forgetting agent` total time:0.176 seconds. avg time per agent cycle: 0.176/500 seconds
+---

--- a/benchmarks/agents_profile_result.md
+++ b/benchmarks/agents_profile_result.md
@@ -90,13 +90,17 @@ This report summarizes the profiling results across all five core attention agen
 
 ## 4. Hebbain Creation 
 
-| Function                      | Calls     | Self Time     | Children Time | Total Time    |
-|-------------------------------|-----------|---------------|---------------|---------------|
-| `addHebbian` (hyp/batch spec) | 10,006    | 0.02s ( 0.6%) | 2.32s (82.8%) | 2.34s (83.4%) |
-| `bach-p` (addHebbian spec)    | 1,997     | 0.01s ( 0.3%) | 2.45s (87.5%) | 2.46s (87.8%) |
-| `batch` (addHebbian spec)     | 2,006     | 0.00s ( 0.2%) | 2.36s (84.4%) | 2.36s (84.6%) |
-| `localToFarLinks`             | 1,000     | 0.00s ( 0.1%) | 0.00s ( 0.0%) | 0.00s ( 0.1%) |
-| `first-k`                     | 2,000     | 0.01s ( 0.3%) | 0.01s ( 0.5%) | 0.02s ( 0.8%) |
+| Function                             | Calls | Self Time    | Children Time | Total Time    | 
+|--------------------------------------|-------|--------------|---------------|---------------|
+| `addHebbian` (hyp_Spec_[addHebbian]) | 6,006 | 0.02s (0.3%) | 2.61s (46.0%) | 2.63s (46.3%) |
+| `bach-p` (parallel dispatcher)       | 1,991 | 0.00s (0.1%) | 2.39s (42.0%) | 2.39s (42.1%) |
+| `batch` (batch partitioner)          | 1,000 | 0.01s (0.3%) | 2.23s (39.3%) | 2.24s (39.6%) |
+| `hyp` (hypothesis evaluator)         | 4,000 | 0.00s (0.1%) | 2.21s (39.0%) | 2.21s (39.1%) |
+| `getValueType`                       | 6,017 | 0.01s (0.1%) | 0.10s (1.8%)  | 0.11s (1.9%)  |
+| `profileAddFromOutSideAF`            | 1     | 0.00s (0.1%) | 0.04s (0.8%)  | 0.04s (0.9%)  |
+| `first-k`                            | 2,000 | 0.02s (0.3%) | 0.02s (0.4%)  | 0.04s (0.7%)  |
+| `subtraction-atom`                   | 2,900 | 0.00s (0.1%) | 0.03s (0.6%)  | 0.03s (0.7%)  | 
+| `size-atom`                          | 23,500| 0.01s (0.2%) | 0.01s (0.3%)  | 0.02s (0.5%)  | 
 
 - `hebbian creation agent` agent time:14.995 seconds, avg time per agent cycle: 14.995/500 seconds
 ---
@@ -119,3 +123,5 @@ This report summarizes the profiling results across all five core attention agen
 
 - `Forgetting agent` total time:0.176 seconds. avg time per agent cycle: 0.176/500 seconds
 ---
+
+- beside the actual application level functions the execution time was consumed by many other low level functions like `reduce`, `match`, `format`, `thread_*`, `current_op`, `cyclic_term`, `$garbage_collect` and others. 

--- a/benchmarks/profile_forgetting_agent.metta
+++ b/benchmarks/profile_forgetting_agent.metta
@@ -1,0 +1,150 @@
+!(import! &self lib/lib_he)
+!(import! &self lib/lib_spaces)
+!(import! &self ../attention/AttentionParam)
+!(import! &self ../attention-bank/utilities/helper-functions)
+!(import! &self ../attention-bank/utilities/recentVal)
+!(import! &self ../attention-bank/attention-value/getter-and-setter)
+!(import! &self ../attention-bank/bank/importance-index/importance-index)
+!(import! &self ../attention-bank/bank/attentional-focus/attentional-focus)
+!(import! &self ../attention-bank/bank/attention-bank)
+!(import! &self ../attention/ForgettingAgent/ForgettingAgent)
+
+; Attention parameters
+!(updateAttentionParam FUNDS_STI        100000.0)
+!(updateAttentionParam FUNDS_LTI        100000.0)
+!(updateAttentionParam TARGET_STI       5000.0)
+!(updateAttentionParam TARGET_LTI       5000.0)
+!(updateAttentionParam MAX_AF_SIZE      20.0)
+!(updateAttentionParam FORGET_THRESHOLD 0.1)
+!(updateAttentionParam MAX_SIZE         40)
+!(updateAttentionParam ACC_DIV_SIZE     5)
+
+; Seed atoms
+; High-STI atoms (inside AF, high LTI -- should NOT be forgotten)
+!(setAv fa-atom-a (900.0  800.0  0.0))
+!(setAv fa-atom-b (850.0  750.0  0.0))
+!(setAv fa-atom-c (800.0  700.0  0.0))
+
+; Mid-STI atoms (borderline)
+!(setAv fa-atom-f (400.0  200.0  0.0))
+!(setAv fa-atom-g (350.0  180.0  0.0))
+!(setAv fa-atom-h (300.0  150.0  0.0))
+
+; Low-STI / low-LTI atoms (forgettable candidates, VLTI=0 so eligible)
+!(setAv fa-atom-i  (50.0   0.04  0.0))
+!(setAv fa-atom-j  (40.0   0.03  0.0))
+!(setAv fa-atom-k  (30.0   0.02  0.0))
+!(setAv fa-atom-l  (20.0   0.01  0.0))
+!(setAv fa-atom-m  (10.0   0.005 0.0))
+
+; Hebbian links (gives atoms an incoming set for globalIncomingSetByType)
+!(setStv (ASYMMETRIC_HEBBIAN_LINK fa-atom-a fa-atom-b) (0.8 0.9))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK fa-atom-b fa-atom-c) (0.7 0.8))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK fa-atom-f fa-atom-g) (0.5 0.5))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK fa-atom-g fa-atom-h) (0.5 0.5))
+
+; Helper: representative mixed candidate list
+(= (forgettingCandidates)
+    (fa-atom-i fa-atom-j fa-atom-k fa-atom-l fa-atom-m
+     fa-atom-f fa-atom-g fa-atom-h fa-atom-a fa-atom-b)
+)
+
+; filterByLti
+(= (profileFilterByLti $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (filterByLti (forgettingCandidates) 0.1)))
+             (profileFilterByLti (- $n 1))))
+)
+
+; lessThanLtiThenTV
+(= (profileLessThanLtiThenTV $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (lessThanLtiThenTV fa-atom-i fa-atom-j))
+               ($_ (lessThanLtiThenTV fa-atom-a fa-atom-b))
+             )
+             (profileLessThanLtiThenTV (- $n 1))))
+)
+
+; greaterThanLtiThenTV
+(= (profileGreaterThanLtiThenTV $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (greaterThanLtiThenTV fa-atom-i fa-atom-j))
+               ($_ (greaterThanLtiThenTV fa-atom-a fa-atom-b))
+             )
+             (profileGreaterThanLtiThenTV (- $n 1))))
+)
+
+; ForgettingLtiThenTVAscendingSort
+(= (profileForgettingSort $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (ForgettingLtiThenTVAscendingSort (forgettingCandidates))))
+             (profileForgettingSort (- $n 1))))
+)
+
+; atomBelowForgetThreshold
+(= (profileAtomBelowForgetThreshold $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (atomBelowForgetThreshold fa-atom-i 5.0 0.0))
+               ($_ (atomBelowForgetThreshold fa-atom-a 5.0 0.0))
+             )
+             (profileAtomBelowForgetThreshold (- $n 1))))
+)
+
+; refundAV
+!(setAv fa-refund-scratch (50.0 0.04 0.0))
+(= (profileRefundAV $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (refundAV fa-refund-scratch))
+               ; Restore so the next iteration has actual work to do
+               ($_ (setAv fa-refund-scratch (50.0 0.04 0.0)))
+             )
+             (profileRefundAV (- $n 1))))
+)
+
+; globalIncomingSetByType
+(= (profileGlobalIncomingByType $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (globalIncomingSetByType fa-atom-b ASYMMETRIC_HEBBIAN_LINK)))
+             (profileGlobalIncomingByType (- $n 1))))
+)
+
+; checkThenRemoveAtom
+(= (profileCheckThenRemoveAtom $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($candidates (ForgettingLtiThenTVAscendingSort (forgettingCandidates)))
+               ($_ (checkThenRemoveAtom $candidates 2 0))
+             )
+             (profileCheckThenRemoveAtom (- $n 1))))
+)
+
+; forgettingAgent-Run
+(= (profileForgettingAgentRun $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (forgettingAgent-Run (TypeSpace))))
+             (profileForgettingAgentRun (- $n 1))))
+)
+
+!(profileFilterByLti               1000)
+!(profileLessThanLtiThenTV         5000)
+!(profileGreaterThanLtiThenTV      5000)
+!(profileForgettingSort             500)
+!(profileAtomBelowForgetThreshold  5000)
+!(profileRefundAV                   500)
+!(profileGlobalIncomingByType      1000)
+!(profileCheckThenRemoveAtom        200)
+!(profileForgettingAgentRun         100)
+

--- a/benchmarks/profile_hebbian_creation_agent.metta
+++ b/benchmarks/profile_hebbian_creation_agent.metta
@@ -1,0 +1,152 @@
+!(import! &self lib/lib_he)
+!(import! &self lib/lib_spaces)
+!(import! &self ../attention/AttentionParam)
+!(import! &self ../attention/baching)
+!(import! &self ../attention-bank/utilities/helper-functions)
+!(import! &self ../attention-bank/utilities/recentVal)
+!(import! &self ../attention-bank/attention-value/getter-and-setter)
+!(import! &self ../attention-bank/bank/importance-index/importance-index)
+!(import! &self ../attention-bank/bank/attentional-focus/attentional-focus)
+!(import! &self ../attention-bank/bank/attention-bank)
+!(import! &self ../attention/HebbianCreationAgent/HebbianCreationAgent)
+
+; Attention parameters 
+!(updateAttentionParam FUNDS_STI    100000.0)
+!(updateAttentionParam FUNDS_LTI    100000.0)
+!(updateAttentionParam TARGET_STI   5000.0)
+!(updateAttentionParam TARGET_LTI   5000.0)
+!(updateAttentionParam MAX_AF_SIZE  20.0)
+
+; Seed atoms 
+; High-STI atoms 
+!(setAv hc-atom-a (900.0 800.0 0.0))
+!(setAv hc-atom-b (850.0 750.0 0.0))
+!(setAv hc-atom-c (800.0 700.0 0.0))
+!(setAv hc-atom-d (750.0 650.0 0.0))
+!(setAv hc-atom-e (700.0 600.0 0.0))
+
+; Low-STI atoms
+!(setAv hc-atom-x (50.0 50.0 0.0))
+!(setAv hc-atom-y (40.0 40.0 0.0))
+!(setAv hc-atom-z (30.0 30.0 0.0))
+
+; Pre-existing Hebbian links
+!(setStv (ASYMMETRIC_HEBBIAN_LINK hc-atom-a hc-atom-b) (0.8 0.9))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK hc-atom-a hc-atom-c) (0.6 0.7))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK hc-atom-b hc-atom-c) (0.7 0.8))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK hc-atom-c hc-atom-d) (0.5 0.6))
+
+; getTargetNeighbors
+(= (profileGetTargetNeighbors $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getTargetNeighbors hc-atom-a ASYMMETRIC_HEBBIAN_LINK (TypeSpace))))
+             (profileGetTargetNeighbors (- $n 1))))
+)
+
+; addHebbian
+!(setAv hca-src-scratch (600.0 600.0 0.0))
+!(setAv hca-tgt-scratch (400.0 400.0 0.0))
+(= (profileAddHebbian $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (addHebbian hca-src-scratch hca-tgt-scratch)))
+             (profileAddHebbian (- $n 1))))
+)
+
+; addFromOutSideAF
+;(= (profileAddFromOutSideAF $n)
+;   (if (<= $n 0)
+;       0
+;       (let* (($_ (addFromOutSideAF hc-atom-a 1 (getAfAtoms))))
+;             (profileAddFromOutSideAF (- $n 1))))
+;)
+
+(= (profileAddFromOutSideAF $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (addFromOutSideAF hc-atom-a 1 (getAfAtoms)))
+               ($_ (collapse (match (TypeSpace)
+                               ((ASYMMETRIC_HEBBIAN_LINK hc-atom-a $t) $val)
+                               (if (and (not (== $t hc-atom-b)) (not (== $t hc-atom-c)))
+                                   (remove-atom &typeSpace ((ASYMMETRIC_HEBBIAN_LINK hc-atom-a $t) $val))
+                                   (empty)
+                               ))))
+             )
+             (profileAddFromOutSideAF (- $n 1))))
+)
+
+; generateRandom
+(= (profileGenerateRandom $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (generateRandom 2 (getAfAtoms))))
+             (profileGenerateRandom (- $n 1))))
+)
+
+; setDifference
+(= (profileSetDifference $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($existing (getTargetNeighbors hc-atom-a ASYMMETRIC_HEBBIAN_LINK (TypeSpace)))
+               ($_ (setDifference $existing))
+             )
+             (profileSetDifference (- $n 1))))
+)
+
+; getRandomAtomInAF
+(= (profileGetRandomAtomInAF $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getRandomAtomInAF (getAfAtoms))))
+             (profileGetRandomAtomInAF (- $n 1))))
+)
+
+; getRandomAtomNotInAF
+(= (profileGetRandomAtomNotInAF $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getRandomAtomNotInAF (getAfAtoms))))
+             (profileGetRandomAtomNotInAF (- $n 1))))
+)
+
+; getSourceAtom
+(= (profileGetSourceAtom $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (getSourceAtom (ASYMMETRIC_HEBBIAN_LINK hc-atom-a hc-atom-b)))
+               ($_ (getSourceAtom (ASYMMETRIC_HEBBIAN_LINK hc-atom-b hc-atom-c)))
+             )
+             (profileGetSourceAtom (- $n 1))))
+)
+
+; removeLinkRecursively
+(= (profileRemoveLinkRecursively $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (removeLinkRecursively 1 (size-atom (getAfAtoms)) (getAfAtoms))))
+             (profileRemoveLinkRecursively (- $n 1))))
+)
+
+; HebbianCreationAgent-Run
+(= (profileHebbianCreationAgentRun $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (HebbianCreationAgent-Run (TypeSpace))))
+             (profileHebbianCreationAgentRun (- $n 1))))
+)
+
+!(profileGetTargetNeighbors         500)
+!(profileAddHebbian                1000)
+;!(profileAddFromOutSideAF           500)  ;taking long 
+;!(profileGenerateRandom             500)  ;taking long 
+!(profileSetDifference              500)
+!(profileGetRandomAtomInAF         2000)
+!(profileGetRandomAtomNotInAF       500)
+!(profileGetSourceAtom             2000)  
+!(profileRemoveLinkRecursively      200)
+!(profileHebbianCreationAgentRun    100)
+

--- a/benchmarks/profile_hebbian_creation_agent.metta
+++ b/benchmarks/profile_hebbian_creation_agent.metta
@@ -55,18 +55,11 @@
 )
 
 ; addFromOutSideAF
-;(= (profileAddFromOutSideAF $n)
-;   (if (<= $n 0)
-;       0
-;       (let* (($_ (addFromOutSideAF hc-atom-a 1 (getAfAtoms))))
-;             (profileAddFromOutSideAF (- $n 1))))
-;)
-
 (= (profileAddFromOutSideAF $n)
    (if (<= $n 0)
        0
        (let* (
-               ($_ (addFromOutSideAF hc-atom-a 1 (getAfAtoms)))
+               ($_ (collapse (addFromOutSideAF hc-atom-a 1 (getAfAtoms))))
                ($_ (collapse (match (TypeSpace)
                                ((ASYMMETRIC_HEBBIAN_LINK hc-atom-a $t) $val)
                                (if (and (not (== $t hc-atom-b)) (not (== $t hc-atom-c)))
@@ -81,7 +74,7 @@
 (= (profileGenerateRandom $n)
    (if (<= $n 0)
        0
-       (let* (($_ (generateRandom 2 (getAfAtoms))))
+       (let* (($_ (collapse (generateRandom 2 (getAfAtoms)))))
              (profileGenerateRandom (- $n 1))))
 )
 
@@ -100,7 +93,7 @@
 (= (profileGetRandomAtomInAF $n)
    (if (<= $n 0)
        0
-       (let* (($_ (getRandomAtomInAF (getAfAtoms))))
+       (let* (($_ (getRandomAtomInAF)))
              (profileGetRandomAtomInAF (- $n 1))))
 )
 
@@ -108,7 +101,7 @@
 (= (profileGetRandomAtomNotInAF $n)
    (if (<= $n 0)
        0
-       (let* (($_ (getRandomAtomNotInAF (getAfAtoms))))
+       (let* (($_ (getRandomAtomNotInAF)))
              (profileGetRandomAtomNotInAF (- $n 1))))
 )
 
@@ -141,8 +134,8 @@
 
 !(profileGetTargetNeighbors         500)
 !(profileAddHebbian                1000)
-;!(profileAddFromOutSideAF           500)  ;taking long 
-;!(profileGenerateRandom             500)  ;taking long 
+!(profileAddFromOutSideAF           500)  
+!(profileGenerateRandom             200)  
 !(profileSetDifference              500)
 !(profileGetRandomAtomInAF         2000)
 !(profileGetRandomAtomNotInAF       500)

--- a/benchmarks/profile_hebbian_updating_agent.metta
+++ b/benchmarks/profile_hebbian_updating_agent.metta
@@ -1,0 +1,116 @@
+!(import! &self lib/lib_he)
+!(import! &self lib/lib_spaces)
+!(import! &self ../attention/AttentionParam)
+!(import! &self ../attention/baching)
+!(import! &self ../attention-bank/utilities/helper-functions)
+!(import! &self ../attention-bank/utilities/recentVal)
+!(import! &self ../attention-bank/attention-value/getter-and-setter)
+!(import! &self ../attention-bank/bank/importance-index/importance-index)
+!(import! &self ../attention-bank/bank/attentional-focus/attentional-focus)
+!(import! &self ../attention-bank/bank/attention-bank)
+!(import! &self ../attention/HebbianUpdatingAgent/HebbianUpdatingAgent)
+
+; Attention parameters 
+!(updateAttentionParam FUNDS_STI     100000.0)
+!(updateAttentionParam FUNDS_LTI     100000.0)
+!(updateAttentionParam TARGET_STI    5000.0)
+!(updateAttentionParam TARGET_LTI    5000.0)
+!(updateAttentionParam MAX_AF_SIZE   20.0)
+!(updateAttentionParam TC_DECAY_RATE 0.1)
+!(updateAttentionParam DEFAULT_K     800)
+
+; Seed atoms 
+!(setAv hu-atom-a (900.0 800.0 0.0))
+!(setAv hu-atom-b (850.0 750.0 0.0))
+!(setAv hu-atom-c (800.0 700.0 0.0))
+!(setAv hu-atom-d (750.0 650.0 0.0))
+
+; Hebbian links 
+; These are the links getAllIncomingSetsForHUAgent and updateHebbianLinks query.
+!(setStv (ASYMMETRIC_HEBBIAN_LINK hu-atom-a hu-atom-b) (0.8 0.9))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK hu-atom-a hu-atom-c) (0.6 0.7))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK hu-atom-b hu-atom-c) (0.7 0.8))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK hu-atom-c hu-atom-d) (0.5 0.6))
+
+; getAllIncomingSetsForHUAgent
+(= (profileGetAllIncomingSets $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (collapse (getAllIncomingSetsForHUAgent hu-atom-a (TypeSpace) ASYMMETRIC_HEBBIAN_LINK))))
+             (profileGetAllIncomingSets (- $n 1))))
+)
+
+; getOutGoingAtoms
+(= (profileGetOutGoingAtoms $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getOutGoingAtoms (ASYMMETRIC_HEBBIAN_LINK hu-atom-a hu-atom-b))))
+             (profileGetOutGoingAtoms (- $n 1))))
+)
+
+; targetConjunction
+(= (profileTargetConjunction $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (targetConjunction (hu-atom-a hu-atom-b)))
+               ($_ (targetConjunction (hu-atom-c hu-atom-d)))
+             )
+             (profileTargetConjunction (- $n 1))))
+)
+
+; mergeCalculation -- PLN_BOOK_REVISION
+(= (profileMergeCalculation $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (mergeCalculation (0.6 0.1) (0.5 0.9) PLN_BOOK_REVISION))
+               ($_ (mergeCalculation (0.3 0.5) (0.7 0.8) PLN_BOOK_REVISION))
+             )
+             (profileMergeCalculation (- $n 1))))
+)
+
+; higherConfidenceMerge
+(= (profileHigherConfidenceMerge $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (higherConfidenceMerge (0.6 0.9) (0.4 0.7)))
+               ($_ (higherConfidenceMerge (0.2 0.3) (0.8 0.95)))
+             )
+             (profileHigherConfidenceMerge (- $n 1))))
+)
+
+; updateHebbianLinks
+(= (profileUpdateHebbianLinks $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (updateHebbianLinks hu-atom-a (TypeSpace))))
+             (profileUpdateHebbianLinks (- $n 1))))
+)
+
+; bachUpdateHeb
+(= (profileBachUpdateHeb $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (bachUpdateHeb hu-atom-a ((ASYMMETRIC_HEBBIAN_LINK hu-atom-a hu-atom-b) (TypeSpace)))))
+             (profileBachUpdateHeb (- $n 1))))
+)
+
+; HebbianUpdatingAgent-Run
+(= (profileHebbianUpdatingAgentRun $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (HebbianUpdatingAgent-Run (TypeSpace))))
+             (profileHebbianUpdatingAgentRun (- $n 1))))
+)
+
+!(profileGetAllIncomingSets         500)
+!(profileGetOutGoingAtoms          5000)
+!(profileTargetConjunction         2000)
+!(profileMergeCalculation          2000)
+!(profileHigherConfidenceMerge     5000)
+!(profileUpdateHebbianLinks         500)
+!(profileBachUpdateHeb              500)
+!(profileHebbianUpdatingAgentRun    100)
+

--- a/benchmarks/profile_importance_diffusion_agent.metta
+++ b/benchmarks/profile_importance_diffusion_agent.metta
@@ -1,0 +1,336 @@
+!(import! &self lib/lib_he)
+!(import! &self lib/lib_spaces)
+!(import! &self ../attention/AttentionParam)
+!(import! &self ../attention/baching)
+!(import! &self ../attention-bank/utilities/helper-functions)
+!(import! &self ../attention-bank/utilities/recentVal)
+!(import! &self ../attention-bank/attention-value/getter-and-setter)
+!(import! &self ../attention-bank/bank/importance-index/importance-index)
+!(import! &self ../attention-bank/bank/attentional-focus/attentional-focus)
+!(import! &self ../attention-bank/bank/attention-bank)
+!(import! &self ../attention-bank/bank/stochastic-importance-diffusion/stochastic-importance-diffusion)
+!(import! &self ../attention/Neighbors)
+!(import! &self ../attention/ImportanceDiffusionAgent/ImportanceDiffusionBase/ImportanceDiffusionBase)
+!(import! &self "../attention/ImportanceDiffusionAgent/getelement.py")
+!(import! &self ../attention/ImportanceDiffusionAgent/AFImportanceDiffusionAgent/AFImportanceDiffusionAgent)
+!(import! &self ../attention/ImportanceDiffusionAgent/WAImportanceDiffusionAgent/WAImportanceDiffusionAgent)
+
+; Attention parameters
+!(updateAttentionParam FUNDS_STI                   100000.0)
+!(updateAttentionParam FUNDS_LTI                   100000.0)
+!(updateAttentionParam TARGET_STI                  5000.0)
+!(updateAttentionParam TARGET_LTI                  5000.0)
+!(updateAttentionParam MAX_AF_SIZE                 20.0)
+!(updateAttentionParam MAX_SPREAD_PERCENTAGE       0.4)
+!(updateAttentionParam HEBBIAN_MAX_ALLOCATION_PERCENTAGE 0.05)
+!(updateAttentionParam TOPK                        1)
+
+; Seed atoms 
+!(stimulate id-source  500)
+!(stimulate id-target1 400)
+!(stimulate id-target2 400)
+!(stimulate id-target3 400)
+!(stimulate id-target4 300)
+!(stimulate id-target5 300)
+!(stimulate id-target6 200)
+!(stimulate id-target7 100)
+
+; Hebbian links 
+!(setStv (ASYMMETRIC_HEBBIAN_LINK id-source  id-target1) (0.8 0.9))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK id-source  id-target2) (0.6 0.7))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK id-target1 id-target3) (0.5 0.6))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK id-target2 id-target4) (0.4 0.5))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK id-target3 id-target5) (0.3 0.4))
+
+; Incident space  
+!(bind! &id-incident (new-space))
+!(add-atom &id-incident
+    (id-source
+        (
+            (INHERITANCE_LINK id-target3 id-source)
+            (INHERITANCE_LINK id-source  id-target4)
+            (INHERITANCE_LINK id-source  id-target5)
+            (INHERITANCE_LINK id-source  id-target6)
+        )
+    )
+)
+!(add-atom &id-incident (id-target1 ((INHERITANCE_LINK id-target1 id-source))))
+!(add-atom &id-incident (id-target2 ((INHERITANCE_LINK id-source  id-target2))))
+!(add-atom &id-incident (id-target3 ((INHERITANCE_LINK id-target3 id-source) (INHERITANCE_LINK id-target3 id-target4))))
+!(add-atom &id-incident (id-target4 ((INHERITANCE_LINK id-source  id-target4))))
+!(add-atom &id-incident (id-target5 ((INHERITANCE_LINK id-source  id-target5))))
+!(add-atom &id-incident (id-target6 ((INHERITANCE_LINK id-source  id-target6))))
+
+; Scratch atoms for tradeSti / tradeList benchmarks 
+!(stimulate id-trade-src 600)
+!(stimulate id-trade-tgt 200)
+
+; =============================================================================
+; ImportanceDiffusionBase primitives
+; =============================================================================
+
+; filteroset
+; Filters ASYMMETRIC_HEBBIAN_LINK atoms out of an outgoing-set list.
+(= (profileFilteroset $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($oset (collapse (match (TypeSpace) (($x $y $z) $val) ($x $y $z))))
+               ($_ (collapse (filteroset $oset)))
+             )
+             (profileFilteroset (- $n 1))))
+)
+
+; incidentAtoms
+; Looks up the incident-atom list for an atom in the incident space.
+(= (profileIncidentAtoms $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (collapse (incidentAtoms id-source  &id-incident)))
+               ($_ (collapse (incidentAtoms id-target1 &id-incident)))
+             )
+             (profileIncidentAtoms (- $n 1))))
+)
+
+; probabilityVectorIncident
+; Builds uniform probability vector over incident atoms.
+(= (profileProbabilityVectorIncident $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($inc (collapse (incidentAtoms id-source &id-incident)))
+               ($_   (collapse (probabilityVectorIncident $inc)))
+             )
+             (profileProbabilityVectorIncident (- $n 1))))
+)
+
+; probabilityVectorHebbianAjacent
+; Builds weighted probability vector over hebbian-adjacent atoms.
+(= (profileProbabilityVectorHebbian $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($iset (collapse (match (TypeSpace) ((ASYMMETRIC_HEBBIAN_LINK id-source $b) $a) $b)))
+               ($_    (collapse (probabilityVectorHebbianAjacent id-source $iset)))
+             )
+             (profileProbabilityVectorHebbian (- $n 1))))
+)
+
+; combineIncidentAdjacentVectors
+; Merges incident and hebbian probability vectors with hebbian-cap logic.
+(= (profileCombineVectors $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($inc    (collapse (incidentAtoms id-source &id-incident)))
+               ($pvInc  (collapse (probabilityVectorIncident $inc)))
+               ($iset   (collapse (match (TypeSpace) ((ASYMMETRIC_HEBBIAN_LINK id-source $b) $a) $b)))
+               ($pvHeb  (collapse (probabilityVectorHebbianAjacent id-source $iset)))
+               ($_      (combineIncidentAdjacentVectors $pvInc $pvHeb))
+             )
+             (profileCombineVectors (- $n 1))))
+)
+
+; calculateHebbianDiffusionPercentation
+; Computes mean × confidence for a hebbian link.
+(= (profileCalcHebbianDiffusionPct $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (calculateHebbianDiffusionPercentation (ASYMMETRIC_HEBBIAN_LINK id-source id-target1)))
+               ($_ (calculateHebbianDiffusionPercentation (ASYMMETRIC_HEBBIAN_LINK id-source id-target2)))
+             )
+             (profileCalcHebbianDiffusionPct (- $n 1))))
+)
+
+; hebbianDiffusionUsed
+; Sums proportions already allocated to hebbian neighbours.
+(= (profileHebbianDiffusionUsed $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($iset  (collapse (match (TypeSpace) ((ASYMMETRIC_HEBBIAN_LINK id-source $b) $a) $b)))
+               ($pvHeb (collapse (probabilityVectorHebbianAjacent id-source $iset)))
+               ($hmax  (getAttentionParam HEBBIAN_MAX_ALLOCATION_PERCENTAGE))
+               ($adjaSize (size-atom $pvHeb))
+               ($hAlloc (if (== $adjaSize 0) 1 (/ $hmax $adjaSize)))
+               ($hProp  (collapse (hebbianProportionSTI $pvHeb $hAlloc)))
+               ($_      (hebbianDiffusionUsed $hProp))
+             )
+             (profileHebbianDiffusionUsed (- $n 1))))
+)
+
+; tradeSti
+; Transfers a fixed STI amount between two atoms.
+(= (profileTradeSti $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (tradeSti id-trade-src id-trade-tgt 5.0))
+               ; Restore balance so subsequent iterations have meaningful work
+               ($_ (tradeSti id-trade-tgt id-trade-src 5.0))
+             )
+             (profileTradeSti (- $n 1))))
+)
+
+; tradeList
+; Aggregates a result list of (source target amount) triples and applies STI
+; trades atomically using the same pattern as spreadImportance.
+!(stimulate id-tl-a 400)
+!(stimulate id-tl-b 300)
+!(stimulate id-tl-c 200)
+(= (idTradeResult)
+    ((id-tl-a id-tl-b 10.0)
+     (id-tl-b id-tl-c  8.0)
+     (id-tl-a id-tl-c  5.0))
+)
+(= (profileTradeList $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (collapse (tradeList (idTradeResult))))
+             )
+             (profileTradeList (- $n 1))))
+)
+
+; diffuseAtom  (ImportanceDiffusionBase full pipeline)
+(= (profileDiffuseAtomAF $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (collapse (diffuseAtom id-source (TypeSpace) AF)))
+             )
+             (profileDiffuseAtomAF (- $n 1))))
+)
+
+; diffuseAtom
+(= (profileDiffuseAtomWA $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (collapse (diffuseAtom id-source (TypeSpace) WA)))
+             )
+             (profileDiffuseAtomWA (- $n 1))))
+)
+
+; =============================================================================
+; AFImportanceDiffusionAgent
+; =============================================================================
+
+; diffuseIncident
+(= (profileDiffuseIncident $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (collapse (diffuseIncident id-source &id-incident)))
+               ($_ (collapse (diffuseIncident id-target1 &id-incident)))
+             )
+             (profileDiffuseIncident (- $n 1))))
+)
+
+; diffuseHebbian
+(= (profileDiffuseHebbian $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($afAtoms (getAfAtoms))
+               ($kSize   (size-atom $afAtoms))
+               ($_ (collapse (diffuseHebbian id-source &id-incident $kSize)))
+             )
+             (profileDiffuseHebbian (- $n 1))))
+)
+
+; AFImportanceDiffusionAgent-Run
+(= (profileAFImportanceDiffusionRun $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (AFImportanceDiffusionAgent-Run &id-incident (TypeSpace)))
+             )
+             (profileAFImportanceDiffusionRun (- $n 1))))
+)
+
+; =============================================================================
+; WAImportanceDiffusionAgent
+; =============================================================================
+
+; diffuseIncidentWA
+(= (profileDiffuseIncidentWA $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($sourceSti (getSti id-source))
+               ($maxSpr    (getAttentionParam MAX_SPREAD_PERCENTAGE))
+               ($hAlloc    (getAttentionParam HEBBIAN_MAX_ALLOCATION_PERCENTAGE))
+               ($diffAmt   (- $sourceSti (diffusedValue id-source $maxSpr)))
+               ($afpct     (* $maxSpr (- 1 $hAlloc)))
+               ($_ (collapse (diffuseIncidentWA id-source &id-incident $diffAmt $afpct)))
+             )
+             (profileDiffuseIncidentWA (- $n 1))))
+)
+
+; diffuseHebbianWA
+(= (profileDiffuseHebbianWA $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($size    (* (getAttentionParam MAX_AF_SIZE) 0.3))
+               ($srcSti  (getSti id-source))
+               ($maxSpr  (getAttentionParam MAX_SPREAD_PERCENTAGE))
+               ($hAlloc  (getAttentionParam HEBBIAN_MAX_ALLOCATION_PERCENTAGE))
+               ($diffAmt (- $srcSti (diffusedValue id-source $maxSpr)))
+               ($hebpct  (* $maxSpr $hAlloc))
+               ($_ (collapse (diffuseHebbianWA id-source $size $diffAmt $hebpct)))
+             )
+             (profileDiffuseHebbianWA (- $n 1))))
+)
+
+; diffuseWA  (WA path — combined incident + hebbian for one atom)
+(= (profileDiffuseWA $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (collapse (diffuseWA id-source &id-incident (TypeSpace))))
+             )
+             (profileDiffuseWA (- $n 1))))
+)
+
+; WAImportanceDiffusionAgent-Run 
+(= (profileWAImportanceDiffusionRun $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (WAImportanceDiffusionAgent-Run &id-incident))
+             )
+             (profileWAImportanceDiffusionRun (- $n 1))))
+)
+
+ 
+
+; ImportanceDiffusionBase primitives
+
+!(profileFilteroset                    1000)
+!(profileIncidentAtoms                 1000)
+!(profileProbabilityVectorIncident     1000)
+!(profileProbabilityVectorHebbian      1000)
+!(profileCombineVectors                 500)
+!(profileCalcHebbianDiffusionPct       5000)
+!(profileHebbianDiffusionUsed           500)
+!(profileTradeSti                      2000)
+!(profileTradeList                      500)
+!(profileDiffuseAtomAF                  200)
+!(profileDiffuseAtomWA                  200)
+
+; AFImportanceDiffusionAgent
+
+!(profileDiffuseIncident                500)
+!(profileDiffuseHebbian                 500)
+!(profileAFImportanceDiffusionRun       100)
+
+; WAImportanceDiffusionAgent
+
+!(profileDiffuseIncidentWA              500)
+!(profileDiffuseHebbianWA               500)
+!(profileDiffuseWA                      200)
+!(profileWAImportanceDiffusionRun       100)

--- a/benchmarks/profile_rent_collection_agent.metta
+++ b/benchmarks/profile_rent_collection_agent.metta
@@ -1,0 +1,213 @@
+!(import! &self lib/lib_he)
+!(import! &self lib/lib_spaces)
+!(import! &self ../attention/AttentionParam)
+!(import! &self ../attention/baching)
+!(import! &self ../attention-bank/utilities/helper-functions)
+!(import! &self ../attention-bank/utilities/recentVal)
+!(import! &self ../attention-bank/attention-value/getter-and-setter)
+!(import! &self ../attention-bank/bank/importance-index/importance-index)
+!(import! &self ../attention-bank/bank/attentional-focus/attentional-focus)
+!(import! &self ../attention-bank/bank/attention-bank)
+!(import! &self ../attention-bank/bank/stochastic-importance-diffusion/stochastic-importance-diffusion)
+!(import! &self ../attention/Neighbors)
+!(import! &self ../attention/RentCollectionAgent/RentCollectionBaseAgent/RentCollectionBaseAgent)
+!(import! &self ../attention/RentCollectionAgent/AFRentCollectionAgent/AFRentCollectionAgent)
+!(import! &self ../attention/RentCollectionAgent/WARentCollectionAgent/WARentCollectionAgent)
+
+; Attention parameters 
+!(updateAttentionParam FUNDS_STI               100000.0)
+!(updateAttentionParam FUNDS_LTI               100000.0)
+!(updateAttentionParam TARGET_STI              5000.0)
+!(updateAttentionParam TARGET_LTI              5000.0)
+!(updateAttentionParam MAX_AF_SIZE             10.0)
+!(updateAttentionParam STI_FUNDS_BUFFER        10000.0)
+!(updateAttentionParam LTI_FUNDS_BUFFER        10000.0)
+!(updateAttentionParam StartingAtomStiRent     1.0)
+!(updateAttentionParam StartingAtomLtiRent     1.0)
+!(updateAttentionParam AFRentFrequency         5.0)
+
+; Seed atoms 
+; High-STI atoms, serve as AF rent targets
+!(stimulate rc-atom-a 3000.0)
+!(stimulate rc-atom-b 2500.0)
+!(stimulate rc-atom-c 2000.0)
+!(stimulate rc-atom-d 1500.0)
+!(stimulate rc-atom-e 1000.0)
+
+; Low-STI atoms, serve as WA rent targets
+!(stimulate rc-atom-f  290.0)
+!(stimulate rc-atom-g  200.0)
+!(stimulate rc-atom-h  100.0)
+!(stimulate (rc-link-ab rc-atom-a rc-atom-b)  50.0)
+!(stimulate (rc-link-cd rc-atom-c rc-atom-d)   5.0)
+
+; =============================================================================
+; RentCollectionBaseAgent
+; =============================================================================
+
+; calculateStiRent
+(= (profileCalculateStiRent $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($base (getAttentionParam StartingAtomStiRent))
+               ($_ (calculateStiRent $base))
+               ; Variant: scaled-up rent value
+               ($_ (calculateStiRent (* $base 10.0)))
+             )
+             (profileCalculateStiRent (- $n 1))))
+)
+
+; calculateLtiRent
+(= (profileCalculateLtiRent $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($base (getAttentionParam StartingAtomLtiRent))
+               ($_ (calculateLtiRent $base))
+               ($_ (calculateLtiRent (* $base 10.0)))
+             )
+             (profileCalculateLtiRent (- $n 1))))
+)
+
+; =============================================================================
+; AFRentCollectionAgent
+; =============================================================================
+
+; applyRent
+(= (profileApplyRent $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ; weight = 1.0 simulates one full rent period
+               ($_ (applyRent 1.0 rc-atom-a))
+               ($_ (applyRent 1.0 rc-atom-b))
+               ($_ (applyRent 0.5 (rc-link-ab rc-atom-a rc-atom-b)))
+               ; Restore atom values so each iteration has real work to do
+               ($_ (stimulate rc-atom-a 1.0))
+               ($_ (stimulate rc-atom-b 1.0))
+             )
+             (profileApplyRent (- $n 1))))
+)
+
+; collectAFRent
+(= (profileCollectAFRent $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($targets (getAfAtoms))
+               ($_ (collectAFRent $targets))
+             )
+             (profileCollectAFRent (- $n 1))))
+)
+
+; setLastUpdate
+; Removes the current lastUpdate timestamp and inserts the new one.
+(= (profileSetLastUpdate $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($t (timeTime))
+               ($_ (setLastUpdate $t))
+             )
+             (profileSetLastUpdate (- $n 1))))
+)
+
+; setFirstTime
+; Flips the firstTime flag in the &timer space.
+(= (profileSetFirstTime $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (setFirstTime False))
+               ; Restore to True so subsequent iterations exercise the same path
+               ($_ (setFirstTime True))
+             )
+             (profileSetFirstTime (- $n 1))))
+)
+
+; selectAFTargets
+; Retrieves the current attentional-focus atom list.
+(= (profileSelectAFTargets $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (selectAFTargets))
+             )
+             (profileSelectAFTargets (- $n 1))))
+)
+
+; AFRentCollectionAgent-run
+; Full end-to-end AF rent cycle: mutex → getAfAtoms → collectAFRent →
+; setLastUpdate.
+(= (profileAFRentCollectionAgentRun $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (AFRentCollectionAgent-run))
+             )
+             (profileAFRentCollectionAgentRun (- $n 1))))
+)
+
+; =============================================================================
+; WARentCollectionAgent
+; =============================================================================
+
+; selectTargets
+; Returns getRandomAtomNotInAF — picks one atom from outside the AF.
+(= (profileSelectTargets $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (selectTargets))
+             )
+             (profileSelectTargets (- $n 1))))
+)
+
+; collectRent
+(= (profileCollectRentWA $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ; rc-atom-f is outside the AF — a valid WA target
+               ($_ (collectRent rc-atom-f))
+               ($_ (collectRent rc-atom-g))
+               ; Restore STI so each iteration has real work to do
+               ($_ (stimulate rc-atom-f 1.0))
+               ($_ (stimulate rc-atom-g 1.0))
+             )
+             (profileCollectRentWA (- $n 1))))
+)
+
+; WARentCollectionAgent-Run
+; Full end-to-end WA rent cycle: mutex → selectTargets → collectRent.
+(= (profileWARentCollectionAgentRun $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (WARentCollectionAgent-Run))
+             )
+             (profileWARentCollectionAgentRun (- $n 1))))
+)
+
+
+
+; RentCollectionBaseAgent
+
+!(profileCalculateStiRent              5000)
+!(profileCalculateLtiRent              5000)
+
+; AFRentCollectionAgent
+
+!(profileSelectAFTargets               2000)
+!(profileApplyRent                     1000)
+!(profileSetLastUpdate                 2000)
+!(profileSetFirstTime                  2000)
+!(profileCollectAFRent                  200)
+!(profileAFRentCollectionAgentRun       100)
+
+; WARentCollectionAgent
+
+!(profileSelectTargets                 2000)
+!(profileCollectRentWA                  500)
+!(profileWARentCollectionAgentRun       200)

--- a/benchmarks/profile_synapse.metta
+++ b/benchmarks/profile_synapse.metta
@@ -1,0 +1,198 @@
+!(import! &self lib/lib_he)
+!(import! &self lib/lib_spaces)
+!(import! &self ../attention/AttentionParam)
+!(import! &self ../attention/baching)
+!(import! &self ../attention-bank/utilities/helper-functions)
+!(import! &self ../attention-bank/utilities/recentVal)
+!(import! &self ../attention-bank/attention-value/getter-and-setter)
+!(import! &self ../attention-bank/bank/importance-index/importance-index)
+!(import! &self ../attention/Neighbors)
+!(import! &self ../attention-bank/bank/attention-bank)
+!(import! &self ../attention-bank/bank/attentional-focus/attentional-focus)
+!(import! &self ../attention-bank/bank/stochastic-importance-diffusion/stochastic-importance-diffusion)
+!(import! &self ../attention-bank/synapse/community_detector.py)
+!(import! &self ../attention-bank/synapse/topology_metrics.py)
+!(import! &self ../attention-bank/synapse/utils)
+!(import! &self ../attention-bank/synapse/synapse)
+
+; ==============================================================================
+; Hyperparameters & Seed Data Setup
+; ==============================================================================
+
+!(updateAttentionParam FUNDS_STI        100000.0)
+!(updateAttentionParam FUNDS_LTI        100000.0)
+!(updateAttentionParam TARGET_STI       5000.0)
+!(updateAttentionParam TARGET_LTI       5000.0)
+!(updateAttentionParam MAX_AF_SIZE      10.0)
+
+; Seed atoms with Attention Values
+!(setAv syn-atom-a (900.0 800.0 0.0))
+!(setAv syn-atom-b (850.0 750.0 0.0))
+!(setAv syn-atom-c (800.0 700.0 0.0))
+!(setAv syn-atom-d (750.0 650.0 0.0))
+!(setAv syn-atom-e (700.0 600.0 0.0))
+!(setAv syn-atom-f (650.0 550.0 0.0))
+!(setAv syn-atom-g (600.0 500.0 0.0))
+!(setAv syn-atom-h (550.0 450.0 0.0))
+
+; Seed Hebbian links with Strength Truth Values
+!(setStv (ASYMMETRIC_HEBBIAN_LINK syn-atom-a syn-atom-b) (0.8 0.9))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK syn-atom-b syn-atom-c) (0.7 0.8))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK syn-atom-c syn-atom-d) (0.6 0.7))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK syn-atom-d syn-atom-e) (0.5 0.6))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK syn-atom-e syn-atom-f) (0.4 0.5))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK syn-atom-f syn-atom-g) (0.3 0.4))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK syn-atom-g syn-atom-a) (0.2 0.3))
+
+; ==============================================================================
+; Synapse Core Metrics & CIP Lifecycle Profiling (synapse.metta)
+; ==============================================================================
+
+; measure-all-metrics
+(= (profileMeasureAllMetrics $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (measure-all-metrics)))
+             (profileMeasureAllMetrics (- $n 1))))
+)
+
+; initialize-baseline-cip
+(= (profileInitializeBaselineCip $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (initialize-baseline-cip)))
+             (profileInitializeBaselineCip (- $n 1))))
+)
+
+; transition-to-next-cip
+(= (profileTransitionToNextCip $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (transition-to-next-cip)))
+             (profileTransitionToNextCip (- $n 1))))
+)
+
+; getAfResourceUsage
+(= (profileGetAfResourceUsage $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getAfResourceUsage)))
+             (profileGetAfResourceUsage (- $n 1))))
+)
+
+; getStiConcentration
+(= (profileGetStiConcentration $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getStiConcentration)))
+             (profileGetStiConcentration (- $n 1))))
+)
+
+; getLinkDensity
+(= (profileGetLinkDensity $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getLinkDensity)))
+             (profileGetLinkDensity (- $n 1))))
+)
+
+; getPreallocationSpace
+(= (profileGetPreallocationSpace $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getPreallocationSpace)))
+             (profileGetPreallocationSpace (- $n 1))))
+)
+
+; getCognitiveSynergy
+(= (profileGetCognitiveSynergy $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getCognitiveSynergy)))
+             (profileGetCognitiveSynergy (- $n 1))))
+)
+
+; getSelectionModulation
+(= (profileGetSelectionModulation $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getSelectionModulation)))
+             (profileGetSelectionModulation (- $n 1))))
+)
+
+; getConnectionRatio
+(= (profileGetConnectionRatio $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getConnectionRatio)))
+             (profileGetConnectionRatio (- $n 1))))
+)
+
+; getGlobalCoordination
+(= (profileGetGlobalCoordination $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getGlobalCoordination (syn-atom-a syn-atom-b syn-atom-c syn-atom-d))))
+             (profileGetGlobalCoordination (- $n 1))))
+)
+
+; getCognitiveMaintenance
+(= (profileGetCognitiveMaintenance $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getCognitiveMaintenance)))
+             (profileGetCognitiveMaintenance (- $n 1))))
+)
+
+; getEffectiveness / getGlobalEffectiveness / getLocalEffectiveness
+(= (profileGetEffectiveness $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (getEffectiveness))
+               ($_ (getLocalEffectiveness))
+             )
+             (profileGetEffectiveness (- $n 1))))
+)
+
+; getAfCoherence
+(= (profileGetAfCoherence $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getAfCoherence)))
+             (profileGetAfCoherence (- $n 1))))
+)
+
+; getContextRetention
+(= (profileGetContextRetention $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getContextRetention)))
+             (profileGetContextRetention (- $n 1))))
+)
+
+; topologyMetrics
+(= (profileTopologyMetrics $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (topologyMetrics)))
+             (profileTopologyMetrics (- $n 1))))
+)
+
+; Execute Workloads
+!(profileInitializeBaselineCip      50)
+!(profileMeasureAllMetrics         200)
+!(profileTransitionToNextCip        50)
+!(profileGetAfResourceUsage       1000)
+!(profileGetStiConcentration      1000)
+!(profileGetLinkDensity           1000)
+!(profileGetPreallocationSpace     500)
+!(profileGetCognitiveSynergy       200)
+!(profileGetSelectionModulation    500)
+!(profileGetConnectionRatio       1000)
+!(profileGetGlobalCoordination     200)
+!(profileGetCognitiveMaintenance   200)
+!(profileGetEffectiveness          300)
+!(profileGetAfCoherence            500)
+!(profileGetContextRetention       500)
+!(profileTopologyMetrics           200)

--- a/benchmarks/profile_synapse.metta
+++ b/benchmarks/profile_synapse.metta
@@ -179,6 +179,138 @@
              (profileTopologyMetrics (- $n 1))))
 )
 
+; Effectiveness Calculation Chain Profiling
+
+; getMetricsFromSnapshot
+(= (profileGetMetricsFromSnapshot $n)
+   (if (<= $n 0)
+       0
+       (let* (($snap (get-cip-snapshots 0))
+              ($_ (getMetricsFromSnapshot $snap)))
+             (profileGetMetricsFromSnapshot (- $n 1))))
+)
+
+; getTotalResourceCost
+(= (profileGetTotalResourceCost $n)
+   (if (<= $n 0)
+       0
+       (let* (($snap    (get-cip-snapshots 0))
+              ($metrics (getMetricsFromSnapshot $snap))
+              ($_ (getTotalResourceCost $metrics)))
+             (profileGetTotalResourceCost (- $n 1))))
+)
+
+; getAggregateMetricDelta  (requires >= 2 CIP snapshots -- run after profileTransitionToNextCip)
+(= (profileGetAggregateMetricDelta $n)
+   (if (<= $n 0)
+       0
+       (let* (($snap0 (get-cip-snapshots 0))
+              ($snap1 (get-cip-snapshots 1))
+              ($_ (getAggregateMetricDelta $snap0 $snap1)))
+             (profileGetAggregateMetricDelta (- $n 1))))
+)
+
+; calculateEffectiveness  (requires >= 2 CIP snapshots)
+(= (profileCalculateEffectiveness $n)
+   (if (<= $n 0)
+       0
+       (let* (($snap0 (get-cip-snapshots 0))
+              ($snap1 (get-cip-snapshots 1))
+              ($_ (calculateEffectiveness $snap0 $snap1)))
+             (profileCalculateEffectiveness (- $n 1))))
+)
+
+; getGlobalEffectiveness
+(= (profileGetGlobalEffectiveness $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getGlobalEffectiveness)))
+             (profileGetGlobalEffectiveness (- $n 1))))
+)
+
+; getGainedEfficiency
+(= (profileGetGainedEfficiency $n)
+   (if (<= $n 0)
+       0
+       (let* (($index (get-lattest-cip-index))
+              ($_ (getGainedEfficiency $index)))
+             (profileGetGainedEfficiency (- $n 1))))
+)
+
+; getRedundancyDegradation
+(= (profileGetRedundancyDegradation $n)
+   (if (<= $n 0)
+       0
+       (let* (($index (get-lattest-cip-index))
+              ($_ (getRedundancyDegradation $index)))
+             (profileGetRedundancyDegradation (- $n 1))))
+)
+
+
+; CIP Internal Helper Profiling
+
+; updateMaxIndex
+(= (profileUpdateMaxIndex $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (updateMaxIndex)))
+             (profileUpdateMaxIndex (- $n 1))))
+)
+
+; get-lattest-cip-index
+(= (profileGetLattestCipIndex $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (get-lattest-cip-index)))
+             (profileGetLattestCipIndex (- $n 1))))
+)
+
+; get-cip-snapshots
+(= (profileGetCipSnapshots $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (get-cip-snapshots 0)))
+             (profileGetCipSnapshots (- $n 1))))
+)
+
+; get-cip-af
+(= (profileGetCipAf $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (get-cip-af 0)))
+             (profileGetCipAf (- $n 1))))
+)
+
+; has-cip-snapshots
+(= (profileHasCipSnapshots $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (has-cip-snapshots)))
+             (profileHasCipSnapshots (- $n 1))))
+)
+
+; cip-af-series  (fixed bound=3: avoids O(N*iters) cost from accumulated snapshots)
+; Using get-lattest-cip-index here would make cost grow with every prior profileTransitionToNextCip call.
+(= (profileCipAfSeries $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (cip-af-series 0 3)))
+             (profileCipAfSeries (- $n 1))))
+)
+
+
+; getContextRetention 2-arg Variant Profiling
+
+; getContextRetention $prevCip $currCip  (direct 2-arg call, isolated from 0-arg dispatch)
+(= (profileGetContextRetention2Arg $n)
+   (if (<= $n 0)
+       0
+       (let* (($prev (get-cip-af 0))
+              ($curr (getAfAtoms))
+              ($_ (getContextRetention $prev $curr)))
+             (profileGetContextRetention2Arg (- $n 1))))
+)
+
 ; Execute Workloads
 !(profileInitializeBaselineCip      50)
 !(profileMeasureAllMetrics         200)
@@ -196,3 +328,25 @@
 !(profileGetAfCoherence            500)
 !(profileGetContextRetention       500)
 !(profileTopologyMetrics           200)
+
+; Effectiveness chain
+!(profileGetMetricsFromSnapshot       500)
+!(profileGetTotalResourceCost         500)
+!(profileGetAggregateMetricDelta       500)
+!(profileCalculateEffectiveness        500)
+!(profileGetGlobalEffectiveness        500)
+
+; (used only when comparing against a baseline run) rather than core real-time attentional cycle operations
+; !(profileGetGainedEfficiency           500)
+; !(profileGetRedundancyDegradation      500)
+
+; CIP internals
+!(profileUpdateMaxIndex     500)
+!(profileGetLattestCipIndex 500)
+!(profileGetCipSnapshots    500)
+!(profileGetCipAf           500)
+!(profileHasCipSnapshots    500)
+!(profileCipAfSeries       500)  ; changed to fixed bound=3, not accumulated index.
+
+; 2-arg context retention
+!(profileGetContextRetention2Arg   500)

--- a/benchmarks/profile_synapse_python.py
+++ b/benchmarks/profile_synapse_python.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+import sys
+import time
+import argparse
+import cProfile
+import pstats
+import io
+import random
+from pathlib import Path
+from typing import List, Tuple, Any, Dict
+
+# Set up module path to import from attention-bank/synapse
+synapse_dir = Path(__file__).resolve().parent.parent / "attention-bank" / "synapse"
+sys.path.insert(0, str(synapse_dir))
+
+import topology_metrics
+import community_detector
+
+
+# ==============================================================================
+# Synthetic Data Generators (Mocking MeTTa Hebbian Links & Atoms)
+# ==============================================================================
+
+def generate_mock_hebbian_links(
+    num_nodes: int, 
+    link_probability: float = 0.2, 
+    nested_atoms: bool = False
+) -> Tuple[List[str], List[List[Any]]]:
+    """Generates realistic MeTTa-format Hebbian links and AF atoms."""
+    if nested_atoms:
+        nodes = [f"(ConceptNode node_{i})" for i in range(num_nodes)]
+    else:
+        nodes = [f"atom_{i}" for i in range(num_nodes)]
+
+    links = []
+    for i in range(num_nodes):
+        for j in range(i + 1, num_nodes):
+            if random.random() < link_probability:
+                src, tgt = nodes[i], nodes[j]
+                mean = round(random.uniform(0.1, 0.9), 3)
+                conf = round(random.uniform(0.5, 0.95), 3)
+                
+                # Format 1: [["ASYMMETRIC_HEBBIAN_LINK", src, tgt], ["STV", mean, conf]]
+                link_record = [
+                    ["ASYMMETRIC_HEBBIAN_LINK", src, tgt],
+                    ["STV", mean, conf]
+                ]
+                links.append(link_record)
+
+    af_atoms = nodes[:max(1, int(num_nodes * 0.3))]  # Top 30% are in AF
+    return af_atoms, links
+
+
+def generate_structured_mesh(size: int = 5) -> List[List[Any]]:
+    """Generates a structured triangular lattice grid rich in 2-simplices (triangles) and 3-simplices."""
+    links = []
+    for x in range(size):
+        for y in range(size):
+            u = f"v_{x}_{y}"
+            if x + 1 < size:
+                v = f"v_{x+1}_{y}"
+                links.append([["ASYMMETRIC_HEBBIAN_LINK", u, v], ["STV", 0.8, 0.9]])
+            if y + 1 < size:
+                v = f"v_{x}_{y+1}"
+                links.append([["ASYMMETRIC_HEBBIAN_LINK", u, v], ["STV", 0.8, 0.9]])
+            if x + 1 < size and y + 1 < size:
+                v = f"v_{x+1}_{y+1}"
+                links.append([["ASYMMETRIC_HEBBIAN_LINK", u, v], ["STV", 0.8, 0.9]])
+    return links
+
+
+# ==============================================================================
+# Benchmarking Engine
+# ==============================================================================
+
+def benchmark_callable(func, *args, iterations: int = 100) -> Dict[str, float]:
+    """Runs a function for N iterations and returns timing statistics in milliseconds."""
+    # Warmup
+    for _ in range(max(1, iterations // 10)):
+        func(*args)
+
+    times = []
+    for _ in range(iterations):
+        t0 = time.perf_counter()
+        func(*args)
+        t1 = time.perf_counter()
+        times.append((t1 - t0) * 1000.0)  # ms
+
+    total_time = sum(times)
+    avg_time = total_time / len(times)
+    min_time = min(times)
+    max_time = max(times)
+
+    return {
+        "iterations": iterations,
+        "total_ms": total_time,
+        "avg_ms": avg_time,
+        "min_ms": min_time,
+        "max_ms": max_time,
+        "ops_per_sec": (iterations / (total_time / 1000.0)) if total_time > 0 else 0.0
+    }
+
+
+def print_bench_result(name: str, res: Dict[str, float]):
+    print(f"  • {name:<36} | Avg: {res['avg_ms']:>8.4f} ms | Min: {res['min_ms']:>8.4f} ms | Total ({res['iterations']} iter): {res['total_ms']/1000.0:>6.3f} s | {res['ops_per_sec']:>9.1f} ops/s")
+
+
+# ==============================================================================
+# Workloads Suite
+# ==============================================================================
+
+def profile_topology_metrics(scale: str = "medium", iterations: int = 500):
+    print("\n" + "=" * 80)
+    print(f"1. PROFILING: Topology Metrics (topology_metrics.py) — Scale: {scale.upper()}")
+    print("=" * 80)
+
+    configs = {
+        "small": {"nodes": 15, "p": 0.35, "iter": iterations},
+        "medium": {"nodes": 40, "p": 0.25, "iter": iterations},
+        "large": {"nodes": 100, "p": 0.15, "iter": max(20, iterations // 5)}
+    }
+    cfg = configs.get(scale, configs["medium"])
+
+    _, random_links = generate_mock_hebbian_links(cfg["nodes"], cfg["p"])
+    _, nested_links = generate_mock_hebbian_links(cfg["nodes"], cfg["p"], nested_atoms=True)
+    mesh_links = generate_structured_mesh(size=6)
+
+    print(f"  [Dataset: Random Graph ({cfg['nodes']} nodes, {len(random_links)} edges)]")
+    res_norm = benchmark_callable(topology_metrics._normalize_edges, random_links, iterations=cfg["iter"])
+    print_bench_result("Edge Normalization (_normalize_edges)", res_norm)
+
+    res_metric_vals = benchmark_callable(topology_metrics.topology_metric_values, random_links, iterations=cfg["iter"])
+    print_bench_result("Full Metrics (topology_metric_values)", res_metric_vals)
+
+    res_metrics_dict = benchmark_callable(topology_metrics.topology_metrics, random_links, iterations=cfg["iter"])
+    print_bench_result("Full Dictionary (topology_metrics)", res_metrics_dict)
+
+    print(f"\n  [Dataset: Structured 2D Simplicial Mesh ({len(mesh_links)} edges)]")
+    res_mesh = benchmark_callable(topology_metrics.topology_metric_values, mesh_links, iterations=cfg["iter"])
+    print_bench_result("Triangular Mesh Betti Invariants", res_mesh)
+
+    print(f"\n  [Dataset: Nested MeTTa S-Expression Atoms ({len(nested_links)} edges)]")
+    res_nested = benchmark_callable(topology_metrics.topology_metric_values, nested_links, iterations=cfg["iter"])
+    print_bench_result("Nested S-Exp Parsing & Topology", res_nested)
+
+
+def profile_community_detector(scale: str = "medium", iterations: int = 500):
+    print("\n" + "=" * 80)
+    print(f"2. PROFILING: Community Detector (community_detector.py) — Scale: {scale.upper()}")
+    print("=" * 80)
+
+    configs = {
+        "small": {"nodes": 20, "p": 0.3, "iter": iterations},
+        "medium": {"nodes": 60, "p": 0.2, "iter": iterations},
+        "large": {"nodes": 150, "p": 0.1, "iter": max(20, iterations // 5)}
+    }
+    cfg = configs.get(scale, configs["medium"])
+
+    af_atoms, all_links = generate_mock_hebbian_links(cfg["nodes"], cfg["p"])
+
+    print(f"  [Dataset: Active AF Graph ({len(af_atoms)} AF atoms, {len(all_links)} total links)]")
+    
+    res_dyn_modules = benchmark_callable(
+        community_detector.get_dynamic_modules, 
+        af_atoms, 
+        all_links, 
+        iterations=cfg["iter"]
+    )
+    print_bench_result("get_dynamic_modules (AF-scoped)", res_dyn_modules)
+
+    res_hebb_modules = benchmark_callable(
+        community_detector.get_dynamic_hebbian_modules, 
+        all_links, 
+        iterations=cfg["iter"]
+    )
+    print_bench_result("get_dynamic_hebbian_modules (Global)", res_hebb_modules)
+
+
+# ==============================================================================
+# Detailed cProfile Function Call Inspection
+# ==============================================================================
+
+def run_cprofile_analysis(scale: str = "medium"):
+    print("\n" + "=" * 80)
+    print("DETAILED CPROFILE BREAKDOWN (Top Internal Python Function Costs)")
+    print("=" * 80)
+
+    num_nodes = 50 if scale == "medium" else (20 if scale == "small" else 100)
+    af_atoms, links = generate_mock_hebbian_links(num_nodes, 0.25)
+
+    def full_synapse_workload():
+        for _ in range(50):
+            topology_metrics.topology_metric_values(links)
+            community_detector.get_dynamic_modules(af_atoms, links)
+
+    pr = cProfile.Profile()
+    pr.enable()
+    full_synapse_workload()
+    pr.disable()
+
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).sort_stats("cumtime")
+    ps.print_stats(25)
+    print(s.getvalue())
+
+
+# ==============================================================================
+# CLI Entry Point
+# ==============================================================================
+
+def main():
+    parser = argparse.ArgumentParser(description="Profile Synapse Python Implementations")
+    parser.add_argument("--scale", choices=["small", "medium", "large"], default="medium", help="Dataset size scale")
+    parser.add_argument("--iterations", type=int, default=500, help="Number of benchmark iterations")
+    parser.add_argument("--cprofile", action="store_true", help="Run line-level cProfile analysis")
+    args = parser.parse_args()
+
+    random.seed(42)  # Deterministic benchmarking
+
+    print(f"Starting Synapse Python Profiling (Scale: {args.scale}, Iterations: {args.iterations})...")
+    
+    profile_topology_metrics(scale=args.scale, iterations=args.iterations)
+    profile_community_detector(scale=args.scale, iterations=args.iterations)
+
+    if args.cprofile:
+        run_cprofile_analysis(scale=args.scale)
+
+    print("\nProfiling Complete.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/profile_synapse_tentativeratio.metta
+++ b/benchmarks/profile_synapse_tentativeratio.metta
@@ -1,0 +1,51 @@
+!(import! &self lib/lib_he)
+!(import! &self lib/lib_spaces)
+!(import! &self ../attention/AttentionParam)
+!(import! &self ../attention/baching)
+!(import! &self ../attention-bank/utilities/helper-functions)
+!(import! &self ../attention-bank/utilities/recentVal)
+!(import! &self ../attention-bank/attention-value/getter-and-setter)
+!(import! &self ../attention-bank/bank/importance-index/importance-index)
+!(import! &self ../attention/Neighbors)
+!(import! &self ../attention-bank/bank/attention-bank)
+!(import! &self ../attention-bank/bank/attentional-focus/attentional-focus)
+!(import! &self ../attention-bank/bank/stochastic-importance-diffusion/stochastic-importance-diffusion)
+!(import! &self ../attention-bank/synapse/utils)
+!(import! &self ../attention-bank/synapse/tentativeratio)
+
+; ==============================================================================
+; Hyperparameters & Seed Data Setup
+; ==============================================================================
+
+!(updateAttentionParam FUNDS_STI        100000.0)
+!(updateAttentionParam FUNDS_LTI        100000.0)
+!(updateAttentionParam TARGET_STI       5000.0)
+!(updateAttentionParam TARGET_LTI       5000.0)
+!(updateAttentionParam MAX_AF_SIZE      10.0)
+
+; Seed atoms with Attention Values
+!(setAv tr-atom-a (900.0 800.0 0.0))
+!(setAv tr-atom-b (850.0 750.0 0.0))
+!(setAv tr-atom-c (800.0 700.0 0.0))
+
+; ==============================================================================
+; Synapse Tentative Ratio Profiling (tentativeratio.metta)
+; ==============================================================================
+
+; initializeBaselineClip, transitionToNextClip, & gainedEfficiency
+(= (profileTentativeRatio $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($base (initializeBaselineClip (tr-atom-a tr-atom-b)))
+               ($next (transitionToNextClip $base (tr-atom-a tr-atom-b tr-atom-c) ()))
+               ($_ (gainedEfficiency (tr-atom-a tr-atom-b tr-atom-c) (tr-atom-a tr-atom-b)))
+               ($_ (getClipIndex $next))
+               ($_ (systemPerformance (tr-atom-a tr-atom-b)))
+               ($_ (totalResourceCost (tr-atom-a tr-atom-b)))
+             )
+             (profileTentativeRatio (- $n 1))))
+)
+
+; Execute Workloads
+!(profileTentativeRatio 500)

--- a/benchmarks/profile_synapse_utils.metta
+++ b/benchmarks/profile_synapse_utils.metta
@@ -1,0 +1,144 @@
+!(import! &self lib/lib_he)
+!(import! &self lib/lib_spaces)
+!(import! &self ../attention/AttentionParam)
+!(import! &self ../attention/baching)
+!(import! &self ../attention-bank/utilities/helper-functions)
+!(import! &self ../attention-bank/utilities/recentVal)
+!(import! &self ../attention-bank/attention-value/getter-and-setter)
+!(import! &self ../attention-bank/bank/importance-index/importance-index)
+!(import! &self ../attention/Neighbors)
+!(import! &self ../attention-bank/bank/attention-bank)
+!(import! &self ../attention-bank/bank/attentional-focus/attentional-focus)
+!(import! &self ../attention-bank/bank/stochastic-importance-diffusion/stochastic-importance-diffusion)
+!(import! &self ../attention-bank/synapse/community_detector.py)
+!(import! &self ../attention-bank/synapse/topology_metrics.py)
+!(import! &self ../attention-bank/synapse/utils)
+
+; ==============================================================================
+; Hyperparameters & Seed Data Setup
+; ==============================================================================
+
+!(updateAttentionParam FUNDS_STI        100000.0)
+!(updateAttentionParam FUNDS_LTI        100000.0)
+!(updateAttentionParam TARGET_STI       5000.0)
+!(updateAttentionParam TARGET_LTI       5000.0)
+!(updateAttentionParam MAX_AF_SIZE      10.0)
+
+; Seed atoms with Attention Values
+!(setAv util-atom-a (900.0 800.0 0.0))
+!(setAv util-atom-b (850.0 750.0 0.0))
+!(setAv util-atom-c (800.0 700.0 0.0))
+!(setAv util-atom-d (750.0 650.0 0.0))
+!(setAv util-atom-e (700.0 600.0 0.0))
+
+; Seed Hebbian links with Strength Truth Values
+!(setStv (ASYMMETRIC_HEBBIAN_LINK util-atom-a util-atom-b) (0.8 0.9))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK util-atom-b util-atom-c) (0.7 0.8))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK util-atom-c util-atom-d) (0.6 0.7))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK util-atom-d util-atom-e) (0.5 0.6))
+!(setStv (ASYMMETRIC_HEBBIAN_LINK util-atom-e util-atom-a) (0.4 0.5))
+
+; ==============================================================================
+; Synapse Utils Profiling (utils.metta)
+; ==============================================================================
+
+; recordCipSeries
+(= (profileRecordCipSeries $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (recordCipSeries)))
+             (profileRecordCipSeries (- $n 1))))
+)
+
+; updateAtomHistory & getStiSeries
+(= (profileUpdateAtomHistory $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (updateAtomHistory util-atom-a (+ 800.0 $n) $n))
+               ($_ (getStiSeries util-atom-a))
+             )
+             (profileUpdateAtomHistory (- $n 1))))
+)
+
+; getTotalSti
+(= (profileGetTotalSti $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (getTotalSti (util-atom-a util-atom-b util-atom-c util-atom-d) 0)))
+             (profileGetTotalSti (- $n 1))))
+)
+
+; getHebLinks & getHebLinksWithValues
+(= (profileGetHebLinks $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (getHebLinks (util-atom-a util-atom-b util-atom-c) ()))
+               ($_ (getHebLinksWithValues (util-atom-a util-atom-b util-atom-c) ()))
+             )
+             (profileGetHebLinks (- $n 1))))
+)
+
+; variance & variance-uniform
+(= (profileVariance $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (variance (900.0 850.0 800.0 750.0 700.0)))
+               ($_ (variance-uniform (900.0 850.0 800.0 750.0 700.0)))
+             )
+             (profileVariance (- $n 1))))
+)
+
+; identifyAllHebbianModules & identifyModules
+(= (profileIdentifyModules $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (identifyAllHebbianModules))
+               ($_ (identifyModules (util-atom-a util-atom-b util-atom-c) (getHebLinksWithValues (util-atom-a util-atom-b) ())))
+             )
+             (profileIdentifyModules (- $n 1))))
+)
+
+; pearsonCorrelation & pearsonCorrelationLists
+(= (profilePearsonCorrelation $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (pearsonCorrelation (util-atom-a util-atom-b util-atom-c) 800.0 700.0))
+               ($_ (pearsonCorrelationLists (10.0 20.0 30.0 40.0) (15.0 25.0 35.0 45.0)))
+             )
+             (profilePearsonCorrelation (- $n 1))))
+)
+
+; temporalConjunction & measureCoherence
+(= (profileCoherenceAndConjunction $n)
+   (if (<= $n 0)
+       0
+       (let* (
+               ($_ (temporalConjunction util-atom-a util-atom-b))
+               ($_ (measureCoherence (util-atom-a util-atom-b util-atom-c)))
+             )
+             (profileCoherenceAndConjunction (- $n 1))))
+)
+
+; shanon-entropy
+(= (profileShanonEntropy $n)
+   (if (<= $n 0)
+       0
+       (let* (($_ (shanon-entropy (0.3 0.3 0.2 0.1 0.1))))
+             (profileShanonEntropy (- $n 1))))
+)
+
+; Execute Workloads
+!(profileRecordCipSeries           200)
+!(profileUpdateAtomHistory        1000)
+!(profileGetTotalSti              2000)
+!(profileGetHebLinks              1000)
+!(profileVariance                 2000)
+!(profileIdentifyModules           200)
+!(profilePearsonCorrelation       1000)
+!(profileCoherenceAndConjunction  1000)
+!(profileShanonEntropy            1000)

--- a/benchmarks/synapse_profile_result.md
+++ b/benchmarks/synapse_profile_result.md
@@ -6,20 +6,23 @@ Only application-level functions and direct Python FFI are shown (Prolog built-i
 
 | Synapse Component | Total Time | 
 |-------------------|------------|
-| **Synapse** | **7.368s** |
+| **Synapse** | **18.109s** |
 | **Synapse Utilities** | **4.114s** |
 | **Synapse Tentative Ratio** | **0.225s** |
-| **Total Synapse Suite** | **11.707s** |
+| **Total Synapse Suite** | **22.448s** |
 
 
 ## 1. Synapse
 
 | Function                  | Calls     | Self Time     | Children Time | Total Time    |
 |---------------------------|-----------|---------------|---------------|---------------|
-| `janus:py_call` (Python)  | 17        | 2.61s (35.5%) | 0.05s ( 0.6%) | 2.66s (36.1%) |
-| `getHebLinks`             | 1,009     | 0.01s ( 0.2%) | 0.03s ( 0.4%) | 0.04s ( 0.6%) |
-| `janus:py_call/3`         | 201       | 0.04s ( 0.5%) | 0.00s ( 0.0%) | 0.04s ( 0.5%) |
-| `zipMultiply`             | 200       | 0.02s ( 0.2%) | 0.00s ( 0.0%) | 0.02s ( 0.2%) |
+| `get-cip-snapshots`       | 11,400    | 0.06s ( 0.3%) | 6.43s (35.5%) | 6.49s (35.8%) |
+| `janus:py_call/2` (Python)| 17        | 2.36s (13.0%) | 0.05s ( 0.3%) | 2.41s (13.3%) |
+| `resolve_memoization`     | 90,110    | 0.04s ( 0.2%) | 0.06s ( 0.3%) | 0.10s ( 0.5%) |
+| `get-lattest-cip-index`   | 2,401     | 0.06s ( 0.3%) | 0.01s ( 0.1%) | 0.07s ( 0.4%) |
+| `janus:py_call/3`         | 201       | 0.04s ( 0.2%) | 0.00s ( 0.0%) | 0.04s ( 0.2%) |
+| `janus:py_initialize_/3`  | 1         | 0.03s ( 0.2%) | 0.00s ( 0.0%) | 0.03s ( 0.2%) |
+
 
 
 ## 2. Synapse Utils

--- a/benchmarks/synapse_profile_result.md
+++ b/benchmarks/synapse_profile_result.md
@@ -6,22 +6,59 @@ Only application-level functions and direct Python FFI are shown (Prolog built-i
 
 | Synapse Component | Total Time | 
 |-------------------|------------|
-| **Synapse** | **18.109s** |
+| **Synapse** | **24.949s** |
 | **Synapse Utilities** | **4.114s** |
-| **Synapse Tentative Ratio** | **0.225s** |
-| **Total Synapse Suite** | **22.448s** |
+| **Synapse Tentative Ratio** | **0.600s** |
+| **Total Synapse Suite** | **29.663s** |
 
 
 ## 1. Synapse
 
-| Function                  | Calls     | Self Time     | Children Time | Total Time    |
-|---------------------------|-----------|---------------|---------------|---------------|
-| `get-cip-snapshots`       | 11,400    | 0.06s ( 0.3%) | 6.43s (35.5%) | 6.49s (35.8%) |
-| `janus:py_call/2` (Python)| 17        | 2.36s (13.0%) | 0.05s ( 0.3%) | 2.41s (13.3%) |
-| `resolve_memoization`     | 90,110    | 0.04s ( 0.2%) | 0.06s ( 0.3%) | 0.10s ( 0.5%) |
-| `get-lattest-cip-index`   | 2,401     | 0.06s ( 0.3%) | 0.01s ( 0.1%) | 0.07s ( 0.4%) |
-| `janus:py_call/3`         | 201       | 0.04s ( 0.2%) | 0.00s ( 0.0%) | 0.04s ( 0.2%) |
-| `janus:py_initialize_/3`  | 1         | 0.03s ( 0.2%) | 0.00s ( 0.0%) | 0.03s ( 0.2%) |
+| Function | Calls | Self Time | Children Time | Total Time | % of Synapse |
+|---|---|---|---|---|---|
+| `get-cip-snapshots` | 11,400 | 0.09s ( 0.4%) | 8.35s (33.5%) | **8.44s** | 33.8% |
+| `get-cip-af` | 7,000 | 0.02s ( 0.1%) | 5.09s (20.4%) | **5.11s** | 20.5% |
+| `janus:py_call/2` (Python FFI) | 17 | 3.15s (12.6%) | 0.08s ( 0.3%) | **3.23s** | 12.9% |
+| `profileCipAfSeries` | 2,001 | 0.01s ( 0.0%) | 2.92s (11.7%) | **2.93s** | 11.7% |
+| `cip-af-series` | 2,500 | 0.02s ( 0.1%) | 2.90s (11.6%) | **2.92s** | 11.7% |
+| `getGlobalEffectiveness` | 2,400 | 0.01s ( 0.0%) | 2.60s (10.4%) | **2.61s** | 10.5% |
+| `map-atom` | 2,700 | 0.03s ( 0.1%) | 2.43s ( 9.7%) | **2.46s** | 9.9% |
+| `getStiSeries` | 3,200 | 0.01s ( 0.0%) | 2.22s ( 8.9%) | **2.23s** | 8.9% |
+| `profileGetEffectiveness` | 1,201 | 0.00s ( 0.0%) | 2.00s ( 8.0%) | **2.00s** | 8.0% |
+| `getPreallocationSpace` | 500 | 0.02s ( 0.1%) | 1.58s ( 6.3%) | **1.60s** | 6.4% |
+| `profileGetAggregateMetricDelta` | 1,001 | 0.01s ( 0.0%) | 1.44s ( 5.8%) | **1.45s** | 5.8% |
+| `profileCalculateEffectiveness` | 1,001 | 0.00s ( 0.0%) | 1.39s ( 5.6%) | **1.39s** | 5.6% |
+| `baselineCip` | 1,600 | 0.00s ( 0.0%) | 1.24s ( 5.0%) | **1.24s** | 5.0% |
+| `has-cip-snapshots` | 1,400 | 0.00s ( 0.0%) | 0.98s ( 3.9%) | **0.98s** | 3.9% |
+| `getAv` | 25,666 | 0.02s ( 0.1%) | 0.90s ( 3.6%) | **0.92s** | 3.7% |
+| `getSti` | 24,057 | 0.02s ( 0.1%) | 0.89s ( 3.6%) | **0.91s** | 3.6% |
+| `profileGetContextRetention` | 501 | 0.01s ( 0.0%) | 0.85s ( 3.4%) | **0.86s** | 3.4% |
+| `profileGetMetricsFromSnapshot` | 501 | 0.03s ( 0.1%) | 0.78s ( 3.1%) | **0.81s** | 3.2% |
+| `profileGetTotalResourceCost` | 501 | 0.00s ( 0.0%) | 0.79s ( 3.2%) | **0.79s** | 3.2% |
+| `getStiConcentration` | 1,003 | 0.02s ( 0.1%) | 0.73s ( 2.9%) | **0.75s** | 3.0% |
+| `profileHasCipSnapshots` | 501 | 0.01s ( 0.0%) | 0.71s ( 2.9%) | **0.72s** | 2.9% |
+| `getAllAtomsWithBins` | 3,206 | 0.01s ( 0.0%) | 0.55s ( 2.2%) | **0.56s** | 2.2% |
+| `getSelectionModulation` | 500 | 0.00s ( 0.0%) | 0.27s ( 1.1%) | **0.27s** | 1.1% |
+| `intersection-atom` | 5,000 | 0.09s ( 0.4%) | 0.16s ( 0.6%) | **0.25s** | 1.0% |
+| `resolve_memoization` | 90,110 | 0.04s ( 0.2%) | 0.15s ( 0.6%) | **0.19s** | 0.8% |
+| `getAfResourceUsage` | 1,003 | 0.01s ( 0.0%) | 0.13s ( 0.5%) | **0.14s** | 0.6% |
+| `pearsonCorrelationLists` | 200 | 0.01s ( 0.1%) | 0.13s ( 0.5%) | **0.14s** | 0.6% |
+| `getHebLinks` | 1,009 | 0.05s ( 0.2%) | 0.04s ( 0.2%) | **0.09s** | 0.4% |
+| `averageList` | 2,000 | 0.00s ( 0.0%) | 0.08s ( 0.3%) | **0.08s** | 0.3% |
+| `getContextRetention` | 1,000 | 0.02s ( 0.1%) | 0.04s ( 0.2%) | **0.06s** | 0.2% |
+| `getAfAtoms` | 4,019 | 0.00s ( 0.0%) | 0.06s ( 0.2%) | **0.06s** | 0.2% |
+| `janus:py_call/3` | 201 | 0.05s ( 0.2%) | 0.00s ( 0.0%) | **0.05s** | 0.2% |
+| `janus:py_initialize_/3` | 1 | 0.05s ( 0.2%) | 0.00s ( 0.0%) | **0.05s** | 0.2% |
+| `calculateEffectiveness` | 1,600 | 0.00s ( 0.0%) | 0.05s ( 0.2%) | **0.05s** | 0.2% |
+| `getAggregateMetricDelta` | 2,100 | 0.00s ( 0.0%) | 0.05s ( 0.2%) | **0.05s** | 0.2% |
+| `getTotalResourceCost` | 2,100 | 0.03s ( 0.1%) | 0.01s ( 0.0%) | **0.04s** | 0.2% |
+| `entropyTerm` | 4,000 | 0.03s ( 0.1%) | 0.01s ( 0.0%) | **0.04s** | 0.2% |
+| `union-atom` | 59,366 | 0.00s ( 0.0%) | 0.04s ( 0.1%) | **0.04s** | 0.1% |
+| `get-lattest-cip-index` | 2,401 | 0.02s ( 0.1%) | 0.01s ( 0.0%) | **0.03s** | 0.1% |
+| `size-atom` | 15,516 | 0.02s ( 0.1%) | 0.01s ( 0.0%) | **0.03s** | 0.1% |
+| `averageMetricScore` | 4,200 | 0.00s ( 0.0%) | 0.02s ( 0.1%) | **0.02s** | 0.1% |
+| `car-atom` | 35,749 | 0.01s ( 0.1%) | 0.00s ( 0.0%) | **0.01s** | 0.0% |
+
 
 
 
@@ -48,9 +85,25 @@ Only application-level functions and direct Python FFI are shown (Prolog built-i
 
 
 
-## 3. Synapse Tentative Ratio 
-- No application-level functions exceeded 0.001s self time.
-> - All 500 iterations of `profileTentativeRatio` executed in under **0.225 seconds total**.
+## 3. Synapse Tentative Ratio
+
+| Function | Calls | Self Time | Children Time | Total Time | % of Benchmark |
+|---|---|---|---|---|---|
+| `janus:py_initialize_/3` (Python) | 1 | 0.08s (13.2%) | 0.00s (0.0%) | **0.08s** | 13.2% |
+| `janus:py_call/1` (Python FFI) | 1 | 0.05s ( 8.2%) | 0.00s (0.0%) | **0.05s** | 8.2% |
+| `profileTentativeRatio` | 1 | 0.00s ( 0.0%) | 0.01s (1.5%) | **0.01s** | 1.5% |
+| `systemPerformance` | 1,500 | 0.00s ( 0.0%) | 0.00s (0.0%) | **<0.001s** | <0.1% |
+| `getClipIndex` | 1,000 | 0.00s ( 0.0%) | 0.00s (0.0%) | **<0.001s** | <0.1% |
+| `measureAllMetrics` | 1,000 | 0.00s ( 0.0%) | 0.00s (0.0%) | **<0.001s** | <0.1% |
+| `cipCurrentTime` | 1,000 | 0.00s ( 0.0%) | 0.00s (0.0%) | **<0.001s** | <0.1% |
+| `initializeBaselineClip` | 500 | 0.00s ( 0.0%) | 0.00s ( 0.0%) | **<0.001s** | <0.1% |
+| `gainedEfficiency` | 500 | 0.00s ( 0.0%) | 0.00s ( 0.0%) | **<0.001s** | <0.1% |
+| `resolve_memoization` | 746 | 0.00s ( 0.0%) | 0.00s ( 0.0%) | **<0.001s** | <0.1% |
+| `getAttentionParam` | 18 | 0.00s ( 0.0%) | 0.00s ( 0.0%) | **<0.001s** | <0.1% |
+| `getValueType` | 12 | 0.00s ( 0.0%) | 0.00s ( 0.0%) | **<0.001s** | <0.1% |
+| `setAv` | 9 | 0.00s ( 0.0%) | 0.00s ( 0.0%) | **<0.001s** | <0.1% |
+| `getAv` | 8 | 0.00s ( 0.0%) | 0.00s ( 0.0%) | **<0.001s** | <0.1% |
+
 
 
 ## 4. Synapse Topology Metrics (Python)

--- a/benchmarks/synapse_profile_result.md
+++ b/benchmarks/synapse_profile_result.md
@@ -1,0 +1,38 @@
+# Profile Results
+
+Only application-level functions are shown (Prolog built-ins and MeTTa runtime internals excluded).
+
+
+## 1. Synapse
+
+| Function                  | Calls     | Self Time     | Children Time | Total Time    |
+|---------------------------|-----------|---------------|---------------|---------------|
+| `janus:py_call` (Python)  | 17        | 2.61s (35.5%) | 0.05s ( 0.6%) | 2.66s (36.1%) |
+| `getHebLinks`             | 1,009     | 0.01s ( 0.2%) | 0.03s ( 0.4%) | 0.04s ( 0.6%) |
+| `zipMultiply`             | 200       | 0.02s ( 0.2%) | 0.00s ( 0.0%) | 0.02s ( 0.2%) |
+
+
+
+## 2. Synapse Utils
+
+| Function                  | Calls     | Self Time     | Children Time | Total Time    |
+|---------------------------|-----------|---------------|---------------|---------------|
+| `profileUpdateAtomHistory`| 1         | 0.01s ( 0.3%) | 0.55s (13.4%) | 0.56s (13.7%) |
+| `profilePearsonCorrelation`| 1        | 0.01s ( 0.3%) | 0.46s (11.2%) | 0.47s (11.5%) |
+| `updateAtomHistory`       | 2,001     | 0.01s ( 0.2%) | 0.45s (11.0%) | 0.46s (11.2%) |
+| `getValueType`            | 21,023    | 0.00s ( 0.1%) | 0.30s ( 7.2%) | 0.30s ( 7.3%) |
+| `getAv`                   | 21,012    | 0.00s ( 0.1%) | 0.30s ( 7.3%) | 0.30s ( 7.4%) |
+| `pearsonCorrelationLists` | 1,000     | 0.01s ( 0.2%) | 0.16s ( 3.9%) | 0.17s ( 4.1%) |
+| `shanon-entropy`          | 1,000     | 0.01s ( 0.2%) | 0.10s ( 2.4%) | 0.11s ( 2.6%) |
+| `meanDiff`                | 3,000     | 0.00s ( 0.1%) | 0.07s ( 1.8%) | 0.07s ( 1.9%) |
+| `getHebLinks`             | 1,001     | 0.01s ( 0.3%) | 0.02s ( 0.4%) | 0.03s ( 0.7%) |
+| `profileGetHebLinks`      | 1         | 0.00s ( 0.1%) | 0.03s ( 0.7%) | 0.03s ( 0.8%) |
+| `variance-uniform`        | 2,000     | 0.01s ( 0.3%) | 0.02s ( 0.4%) | 0.03s ( 0.7%) |
+| `zipMultiply`             | 1,001     | 0.00s ( 0.1%) | 0.02s ( 0.4%) | 0.02s ( 0.5%) |
+| `getHebLinksWithValues`   | 1,200     | 0.01s ( 0.3%) | 0.00s ( 0.1%) | 0.01s ( 0.4%) |
+| `log-math`                | 5,005     | 0.01s ( 0.2%) | 0.00s ( 0.1%) | 0.01s ( 0.3%) |
+
+
+
+## 3. Synapse Tentative Ratio 
+- No application-level functions exceeded 0.00s self time.

--- a/benchmarks/synapse_profile_result.md
+++ b/benchmarks/synapse_profile_result.md
@@ -1,6 +1,15 @@
 # Profile Results
 
-Only application-level functions are shown (Prolog built-ins and MeTTa runtime internals excluded).
+Only application-level functions and direct Python FFI are shown (Prolog built-ins and MeTTa runtime internals excluded).
+
+### Synapse Overview
+
+| Synapse Component | Total Time | 
+|-------------------|------------|
+| **Synapse** | **7.368s** |
+| **Synapse Utilities** | **4.114s** |
+| **Synapse Tentative Ratio** | **0.225s** |
+| **Total Synapse Suite** | **11.707s** |
 
 
 ## 1. Synapse
@@ -9,14 +18,15 @@ Only application-level functions are shown (Prolog built-ins and MeTTa runtime i
 |---------------------------|-----------|---------------|---------------|---------------|
 | `janus:py_call` (Python)  | 17        | 2.61s (35.5%) | 0.05s ( 0.6%) | 2.66s (36.1%) |
 | `getHebLinks`             | 1,009     | 0.01s ( 0.2%) | 0.03s ( 0.4%) | 0.04s ( 0.6%) |
+| `janus:py_call/3`         | 201       | 0.04s ( 0.5%) | 0.00s ( 0.0%) | 0.04s ( 0.5%) |
 | `zipMultiply`             | 200       | 0.02s ( 0.2%) | 0.00s ( 0.0%) | 0.02s ( 0.2%) |
-
 
 
 ## 2. Synapse Utils
 
 | Function                  | Calls     | Self Time     | Children Time | Total Time    |
 |---------------------------|-----------|---------------|---------------|---------------|
+| `janus:py_call`           | 15        | 1.79s (43.6%) | 0.04s (1.1%)  | 1.83s (44.7%) |
 | `profileUpdateAtomHistory`| 1         | 0.01s ( 0.3%) | 0.55s (13.4%) | 0.56s (13.7%) |
 | `profilePearsonCorrelation`| 1        | 0.01s ( 0.3%) | 0.46s (11.2%) | 0.47s (11.5%) |
 | `updateAtomHistory`       | 2,001     | 0.01s ( 0.2%) | 0.45s (11.0%) | 0.46s (11.2%) |
@@ -25,6 +35,7 @@ Only application-level functions are shown (Prolog built-ins and MeTTa runtime i
 | `pearsonCorrelationLists` | 1,000     | 0.01s ( 0.2%) | 0.16s ( 3.9%) | 0.17s ( 4.1%) |
 | `shanon-entropy`          | 1,000     | 0.01s ( 0.2%) | 0.10s ( 2.4%) | 0.11s ( 2.6%) |
 | `meanDiff`                | 3,000     | 0.00s ( 0.1%) | 0.07s ( 1.8%) | 0.07s ( 1.9%) |
+| `janus:py_call/3`         | 400       | 0.05s ( 1.2%) | 0.00s ( 0.0%) | 0.05s ( 1.2%) |
 | `getHebLinks`             | 1,001     | 0.01s ( 0.3%) | 0.02s ( 0.4%) | 0.03s ( 0.7%) |
 | `profileGetHebLinks`      | 1         | 0.00s ( 0.1%) | 0.03s ( 0.7%) | 0.03s ( 0.8%) |
 | `variance-uniform`        | 2,000     | 0.01s ( 0.3%) | 0.02s ( 0.4%) | 0.03s ( 0.7%) |
@@ -35,4 +46,24 @@ Only application-level functions are shown (Prolog built-ins and MeTTa runtime i
 
 
 ## 3. Synapse Tentative Ratio 
-- No application-level functions exceeded 0.00s self time.
+- No application-level functions exceeded 0.001s self time.
+> - All 500 iterations of `profileTentativeRatio` executed in under **0.225 seconds total**.
+
+
+## 4. Synapse Topology Metrics (Python)
+
+| Function | Calls | Avg Time | Min Time | Total Time |
+|--------------------|-------|----------|----------|------------|
+| `Full Metrics` (`topology_metric_values`) | 200 | 31.21 ms | 27.50 ms | 6.242s |
+| `Full Dictionary` (`topology_metrics`) | 200 | 30.93 ms | 27.46 ms | 6.185s |
+| `Nested S-Exp Parsing & Topology` | 200 | 29.26 ms | 25.94 ms | 5.852s |
+| `Edge Normalization` (`_normalize_edges`) | 200 | 6.26 ms | 5.23 ms | 1.252s |
+| `Triangular Mesh Invariants` | 200 | 1.02 ms | 0.77 ms | 0.204s |
+
+
+## 5. Synapse Community Detector (Python)
+
+| Function | Calls | Avg Time | Min Time | Total Time |
+|--------------------|-------|----------|----------|------------|
+| `get_dynamic_modules` *(AF-scoped)* | 200 | 6.33 ms | 4.42 ms | 1.265s |
+| `get_dynamic_hebbian_modules` *(Global)* | 200 | 5.42 ms | 4.48 ms | 1.084s |


### PR DESCRIPTION
## These is the followup implementations of metta-attention code profiling

- these phase includes profiling of agents inside attention dir.
- forgettingAgent, HebbianUpdatingAgent are succussfully profiled
- profiling added for importance diffusion agent and rent collection agent.
- compiled the profile results of agent and synapse profiling  in separate .md file.
- agent level profiling results included with the time it took.

**fixes**  
- Replace undefined (forgetThreshold) call in atomBelowForgetThreshold with
  (getAttentionParam FORGET_THRESHOLD) to fix Prolog type error.

- `getRandomAtomInAF` in **attentional-focus.metta** takes no parameters (), because it internally calls  (getAfAtoms). therefore the parameter `(getAfAtoms)` that is passed to these function in **HebbianCreationAgent.metta** is removed.

