### PR TITLE
Fix/synapse metrics

### DIFF
--- a/synapse/utils.metta
+++ b/synapse/utils.metta
@@ -314,23 +314,10 @@
     )
 )
 
-(= (stiProbablity $atomSti $allSti)
+(= (shanon-entropy $distribution)
     (let*
         (
-            ($stiCount (car-atom (intersection-atom $allSti $atomSti)))
-            ($ratio (/ $stiCount (size-atom $allSti)))
-        )
-        $ratio
-    )
-)
-
-(= (shanon-entropy $stiDistribution)
-    (let*
-        (
-            ($probabilities
-                (map-atom $stiDistribution $atom (stiProbablity ($atom) $stiDistribution))
-            )
-            ($entropyTerms (map-atom $probabilities $p (entropyTerm $p)))
+            ($entropyTerms (map-atom $distribution $p (entropyTerm $p)))
             ($sumTerms (foldl-atom $entropyTerms 0 $acc $x (+ $acc $x)))
         )
         (* -1.0 $sumTerms)
@@ -350,6 +337,13 @@
         (or (== $name betti0)
             (or (== $name betti1)
                 (== $name betti2))))
+)
+
+; Metrics kept out of the performance average: topology, fundSti, effectiveness.
+(= (isExcludedMetric $name)
+    (or (isTopologyMetric $name)
+        (or (== $name fundSti)
+            (== $name effectiveness)))
 )
 
 (= (getMetrics $name $list)
@@ -378,7 +372,7 @@
                     ($tail (cdr-atom $list))
                     ($name (getMetricName $head))
                )
-               (if (isTopologyMetric $name)
+               (if (isExcludedMetric $name)
                    (sumMetrics $tail)
                    (+ (getMetricValue $head) (sumMetrics $tail))
                )
@@ -395,7 +389,7 @@
                   ($tail (cdr-atom $list))
                   ($name (getMetricName $head))
               )
-              (if (isTopologyMetric $name)
+              (if (isExcludedMetric $name)
                   (countMetrics $tail)
                   (+ 1 (countMetrics $tail))
               )

--- a/synapse/utils.metta
+++ b/synapse/utils.metta
@@ -314,10 +314,24 @@
     )
 )
 
+(= (stiProbablity $atomSti $allSti)
+    (let*
+        (
+            ($stiCount (car-atom (intersection-atom $allSti $atomSti)))
+            ($total (foldl-atom $allSti 0 $acc $x (+ $acc $x)))
+        )
+        (if (> $total 0)
+            (/ $stiCount $total)
+            0.0
+        )
+    )
+)
+
 (= (shanon-entropy $distribution)
     (let*
         (
-            ($entropyTerms (map-atom $distribution $p (entropyTerm $p)))
+            ($probabilities (map-atom $distribution $atom (stiProbablity ($atom) $distribution)))
+            ($entropyTerms (map-atom $probabilities $p (entropyTerm $p)))
             ($sumTerms (foldl-atom $entropyTerms 0 $acc $x (+ $acc $x)))
         )
         (* -1.0 $sumTerms)

--- a/synapse/utils.metta
+++ b/synapse/utils.metta
@@ -327,10 +327,12 @@
     )
 )
 
-(= (shanon-entropy $distribution)
+(= (shanon-entropy $stiDistribution)
     (let*
         (
-            ($probabilities (map-atom $distribution $atom (stiProbablity ($atom) $distribution)))
+            ($probabilities (
+                map-atom $stiDistribution $atom (stiProbablity ($atom) $stiDistribution))
+            )
             ($entropyTerms (map-atom $probabilities $p (entropyTerm $p)))
             ($sumTerms (foldl-atom $entropyTerms 0 $acc $x (+ $acc $x)))
         )
@@ -353,7 +355,8 @@
                 (== $name betti2))))
 )
 
-; Metrics kept out of the performance average: topology, fundSti, effectiveness.
+; Metrics kept out of the performance average: topology, fundSti and 
+; effectiveness (prevents restatement of the previous cycle's.)
 (= (isExcludedMetric $name)
     (or (isTopologyMetric $name)
         (or (== $name fundSti)


### PR DESCRIPTION
This PR updates the way metrics are filtered and calculated in `synapse/utils.metta`, specifically improving metric exclusion logic and fixing a calculation bug. The main changes involve introducing a new predicate for excluding certain metrics from performance averages and correcting the denominator in a ratio computation.

**Metric exclusion and calculation improvements:**

* Added a new predicate `isExcludedMetric` to consistently exclude topology, `fundSti`, and `effectiveness` metrics from performance averages, preventing restatement of previous cycle metrics. Updated `sumMetrics` and `countMetrics` to use this predicate instead of only excluding topology metrics. 
* Fixed the denominator in the ratio calculation within the relevant function to use the sum of all STIs instead of just the count, preventing division errors and improving accuracy.